### PR TITLE
Change fullNodePeer to an optional setting for ChiaWallets

### DIFF
--- a/api/v1/chiawallet_types.go
+++ b/api/v1/chiawallet_types.go
@@ -25,7 +25,8 @@ type ChiaWalletSpecChia struct {
 
 	// FullNodePeer defines the farmer's full_node peer in host:port format.
 	// In Kubernetes this is likely to be <node service name>.<namespace>.svc.cluster.local:8555
-	FullNodePeer string `json:"fullNodePeer"`
+	// +optional
+	FullNodePeer string `json:"fullNodePeer,omitempty"`
 }
 
 // ChiaWalletStatus defines the observed state of ChiaWallet

--- a/config/crd/bases/k8s.chia.net_chiawallets.yaml
+++ b/config/crd/bases/k8s.chia.net_chiawallets.yaml
@@ -749,7 +749,6 @@ spec:
                     type: string
                 required:
                 - caSecretName
-                - fullNodePeer
                 - secretKey
                 type: object
               chiaExporter:

--- a/docs/chiawallet.md
+++ b/docs/chiawallet.md
@@ -1,6 +1,6 @@
 # ChiaWallet
 
-Specifying a ChiaWallet will create a kubernetes Deployment and some Services for a Chia wallet that connects to a local [full_node](chianode.md). It also requires a specified [Chia certificate authority](chiaca.md).
+Specifying a ChiaWallet will create a kubernetes Deployment and some Services for a Chia wallet that optionally connects to a local [full_node](chianode.md). It also requires a specified [Chia certificate authority](chiaca.md).
 
 Here's a minimal ChiaWallet example custom resource (CR):
 
@@ -12,7 +12,6 @@ metadata:
 spec:
   chia:
     caSecretName: chiaca-secret # A kubernetes Secret containing certificate authority files
-    fullNodePeer: "node.default.svc.cluster.local:8444" # A local full_node using kubernetes DNS names
     # A kubernetes Secret named chiakey-secret containing a key.txt file with your mnemonic key
     secretKey:
       name: "chiakey-secret"
@@ -29,6 +28,14 @@ spec:
     testnet: true # Switches to the default testnet in the Chia configuration file.
     timezone: "UTC" # Switches the tzdata timezone in the container.
     logLevel: "INFO" # Sets the Chia log level.
+```
+
+You can also give a local full_node as a peer for your wallet. This does not currently automate the process of setting the full_node for trusted sync, but could still speed up the wallet syncing process because a full_node running in your cluster is probably geographically closer than other full_nodes around the world. Set a full_node peer like so:
+
+```yaml
+spec:
+  chia:
+    fullNodePeer: "node.default.svc.cluster.local:8444" # A local full_node using kubernetes DNS names
 ```
 
 ### CHIA_ROOT storage

--- a/internal/controller/chiawallet/helpers.go
+++ b/internal/controller/chiawallet/helpers.go
@@ -130,10 +130,12 @@ func (r *ChiaWalletReconciler) getChiaEnv(ctx context.Context, wallet k8schianet
 	})
 
 	// node peer env var
-	env = append(env, corev1.EnvVar{
-		Name:  "full_node_peer",
-		Value: wallet.Spec.ChiaConfig.FullNodePeer,
-	})
+	if wallet.Spec.ChiaConfig.FullNodePeer != "" {
+		env = append(env, corev1.EnvVar{
+			Name:  "full_node_peer",
+			Value: wallet.Spec.ChiaConfig.FullNodePeer,
+		})
+	}
 
 	return env
 }


### PR DESCRIPTION
You can sync a wallet in "lite" mode without a trusted full_node. Specifying a local full_node should still be an option, but isn't necessary in regular chia use outside of kubernetes, so this just aligns the operator to that.