### PR TITLE
Add provenance label to common labels

### DIFF
--- a/internal/controller/chiaca/assemblers.go
+++ b/internal/controller/chiaca/assemblers.go
@@ -25,7 +25,7 @@ func (r *ChiaCAReconciler) assembleJob(ctx context.Context, ca k8schianetv1.Chia
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiacaNamePattern, ca.Name),
 			Namespace:       ca.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, ca.ObjectMeta),
+			Labels:          kube.GetCommonLabels(ctx, ca.Kind, ca.ObjectMeta),
 			OwnerReferences: r.getOwnerReference(ctx, ca),
 		},
 		Spec: batchv1.JobSpec{
@@ -70,7 +70,7 @@ func (r *ChiaCAReconciler) assembleServiceAccount(ctx context.Context, ca k8schi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiacaNamePattern, ca.Name),
 			Namespace:       ca.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, ca.ObjectMeta),
+			Labels:          kube.GetCommonLabels(ctx, ca.Kind, ca.ObjectMeta),
 			OwnerReferences: r.getOwnerReference(ctx, ca),
 		},
 	}
@@ -82,7 +82,7 @@ func (r *ChiaCAReconciler) assembleRole(ctx context.Context, ca k8schianetv1.Chi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiacaNamePattern, ca.Name),
 			Namespace:       ca.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, ca.ObjectMeta),
+			Labels:          kube.GetCommonLabels(ctx, ca.Kind, ca.ObjectMeta),
 			OwnerReferences: r.getOwnerReference(ctx, ca),
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -107,7 +107,7 @@ func (r *ChiaCAReconciler) assembleRoleBinding(ctx context.Context, ca k8schiane
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiacaNamePattern, ca.Name),
 			Namespace:       ca.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, ca.ObjectMeta),
+			Labels:          kube.GetCommonLabels(ctx, ca.Kind, ca.ObjectMeta),
 			OwnerReferences: r.getOwnerReference(ctx, ca),
 		},
 		Subjects: []rbacv1.Subject{

--- a/internal/controller/chiafarmer/assemblers.go
+++ b/internal/controller/chiafarmer/assemblers.go
@@ -26,7 +26,7 @@ func (r *ChiaFarmerReconciler) assembleBaseService(ctx context.Context, farmer k
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiafarmerNamePattern, farmer.Name),
 			Namespace:       farmer.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, farmer.Kind, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels),
 			Annotations:     farmer.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, farmer),
 		},
@@ -52,7 +52,7 @@ func (r *ChiaFarmerReconciler) assembleBaseService(ctx context.Context, farmer k
 					Name:       "rpc",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, farmer.Kind, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -63,7 +63,7 @@ func (r *ChiaFarmerReconciler) assembleChiaExporterService(ctx context.Context, 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiafarmerNamePattern, farmer.Name) + "-metrics",
 			Namespace:       farmer.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels, farmer.Spec.ChiaExporterConfig.ServiceLabels),
+			Labels:          kube.GetCommonLabels(ctx, farmer.Kind, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels, farmer.Spec.ChiaExporterConfig.ServiceLabels),
 			Annotations:     farmer.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, farmer),
 		},
@@ -77,7 +77,7 @@ func (r *ChiaFarmerReconciler) assembleChiaExporterService(ctx context.Context, 
 					Name:       "metrics",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, farmer.Kind, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -88,17 +88,17 @@ func (r *ChiaFarmerReconciler) assembleDeployment(ctx context.Context, farmer k8
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiafarmerNamePattern, farmer.Name),
 			Namespace:       farmer.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, farmer.Kind, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels),
 			Annotations:     farmer.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, farmer),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: kube.GetCommonLabels(ctx, farmer.ObjectMeta),
+				MatchLabels: kube.GetCommonLabels(ctx, farmer.Kind, farmer.ObjectMeta),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      kube.GetCommonLabels(ctx, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels),
+					Labels:      kube.GetCommonLabels(ctx, farmer.Kind, farmer.ObjectMeta, farmer.Spec.AdditionalMetadata.Labels),
 					Annotations: farmer.Spec.AdditionalMetadata.Annotations,
 				},
 				Spec: corev1.PodSpec{

--- a/internal/controller/chiaharvester/assemblers.go
+++ b/internal/controller/chiaharvester/assemblers.go
@@ -26,7 +26,7 @@ func (r *ChiaHarvesterReconciler) assembleBaseService(ctx context.Context, harve
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiaharvesterNamePattern, harvester.Name),
 			Namespace:       harvester.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, harvester.Kind, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels),
 			Annotations:     harvester.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, harvester),
 		},
@@ -52,7 +52,7 @@ func (r *ChiaHarvesterReconciler) assembleBaseService(ctx context.Context, harve
 					Name:       "rpc",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, harvester.Kind, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -63,7 +63,7 @@ func (r *ChiaHarvesterReconciler) assembleChiaExporterService(ctx context.Contex
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiaharvesterNamePattern, harvester.Name) + "-metrics",
 			Namespace:       harvester.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels, harvester.Spec.ChiaExporterConfig.ServiceLabels),
+			Labels:          kube.GetCommonLabels(ctx, harvester.Kind, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels, harvester.Spec.ChiaExporterConfig.ServiceLabels),
 			Annotations:     harvester.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, harvester),
 		},
@@ -77,7 +77,7 @@ func (r *ChiaHarvesterReconciler) assembleChiaExporterService(ctx context.Contex
 					Name:       "metrics",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, harvester.Kind, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -88,17 +88,17 @@ func (r *ChiaHarvesterReconciler) assembleDeployment(ctx context.Context, harves
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiaharvesterNamePattern, harvester.Name),
 			Namespace:       harvester.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, harvester.Kind, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels),
 			Annotations:     harvester.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, harvester),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: kube.GetCommonLabels(ctx, harvester.ObjectMeta),
+				MatchLabels: kube.GetCommonLabels(ctx, harvester.Kind, harvester.ObjectMeta),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      kube.GetCommonLabels(ctx, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels),
+					Labels:      kube.GetCommonLabels(ctx, harvester.Kind, harvester.ObjectMeta, harvester.Spec.AdditionalMetadata.Labels),
 					Annotations: harvester.Spec.AdditionalMetadata.Annotations,
 				},
 				Spec: corev1.PodSpec{

--- a/internal/controller/chianode/assemblers.go
+++ b/internal/controller/chianode/assemblers.go
@@ -26,7 +26,7 @@ func (r *ChiaNodeReconciler) assembleBaseService(ctx context.Context, node k8sch
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chianodeNamePattern, node.Name),
 			Namespace:       node.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
 			Annotations:     node.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, node),
 		},
@@ -52,7 +52,7 @@ func (r *ChiaNodeReconciler) assembleBaseService(ctx context.Context, node k8sch
 					Name:       "rpc",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -64,7 +64,7 @@ func (r *ChiaNodeReconciler) assembleInternalService(ctx context.Context, node k
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chianodeNamePattern, node.Name) + "-internal",
 			Namespace:       node.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
 			Annotations:     node.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, node),
 		},
@@ -91,7 +91,7 @@ func (r *ChiaNodeReconciler) assembleInternalService(ctx context.Context, node k
 					Name:       "rpc",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -102,7 +102,7 @@ func (r *ChiaNodeReconciler) assembleHeadlessService(ctx context.Context, node k
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chianodeNamePattern, node.Name) + "-headless",
 			Namespace:       node.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
 			Annotations:     node.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, node),
 		},
@@ -129,7 +129,7 @@ func (r *ChiaNodeReconciler) assembleHeadlessService(ctx context.Context, node k
 					Name:       "rpc",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -140,7 +140,7 @@ func (r *ChiaNodeReconciler) assembleChiaExporterService(ctx context.Context, no
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chianodeNamePattern, node.Name) + "-metrics",
 			Namespace:       node.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels, node.Spec.ChiaExporterConfig.ServiceLabels),
+			Labels:          kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels, node.Spec.ChiaExporterConfig.ServiceLabels),
 			Annotations:     node.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, node),
 		},
@@ -154,7 +154,7 @@ func (r *ChiaNodeReconciler) assembleChiaExporterService(ctx context.Context, no
 					Name:       "metrics",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -167,19 +167,19 @@ func (r *ChiaNodeReconciler) assembleStatefulset(ctx context.Context, node k8sch
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chianodeNamePattern, node.Name),
 			Namespace:       node.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
 			Annotations:     node.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, node),
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &node.Spec.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: kube.GetCommonLabels(ctx, node.ObjectMeta),
+				MatchLabels: kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta),
 			},
 			ServiceName: fmt.Sprintf(chianodeNamePattern, node.Name) + "-headless",
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      kube.GetCommonLabels(ctx, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
+					Labels:      kube.GetCommonLabels(ctx, node.Kind, node.ObjectMeta, node.Spec.AdditionalMetadata.Labels),
 					Annotations: node.Spec.AdditionalMetadata.Annotations,
 				},
 				Spec: corev1.PodSpec{

--- a/internal/controller/chiatimelord/assemblers.go
+++ b/internal/controller/chiatimelord/assemblers.go
@@ -26,7 +26,7 @@ func (r *ChiaTimelordReconciler) assembleBaseService(ctx context.Context, tl k8s
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiatimelordNamePattern, tl.Name),
 			Namespace:       tl.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, tl.Kind, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels),
 			Annotations:     tl.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, tl),
 		},
@@ -52,7 +52,7 @@ func (r *ChiaTimelordReconciler) assembleBaseService(ctx context.Context, tl k8s
 					Name:       "rpc",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, tl.Kind, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -63,7 +63,7 @@ func (r *ChiaTimelordReconciler) assembleChiaExporterService(ctx context.Context
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiatimelordNamePattern, tl.Name) + "metrics",
 			Namespace:       tl.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels, tl.Spec.ChiaExporterConfig.ServiceLabels),
+			Labels:          kube.GetCommonLabels(ctx, tl.Kind, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels, tl.Spec.ChiaExporterConfig.ServiceLabels),
 			Annotations:     tl.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, tl),
 		},
@@ -77,7 +77,7 @@ func (r *ChiaTimelordReconciler) assembleChiaExporterService(ctx context.Context
 					Name:       "metrics",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, tl.Kind, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -88,17 +88,17 @@ func (r *ChiaTimelordReconciler) assembleDeployment(ctx context.Context, tl k8sc
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiatimelordNamePattern, tl.Name),
 			Namespace:       tl.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, tl.Kind, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels),
 			Annotations:     tl.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, tl),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: kube.GetCommonLabels(ctx, tl.ObjectMeta),
+				MatchLabels: kube.GetCommonLabels(ctx, tl.Kind, tl.ObjectMeta),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      kube.GetCommonLabels(ctx, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels),
+					Labels:      kube.GetCommonLabels(ctx, tl.Kind, tl.ObjectMeta, tl.Spec.AdditionalMetadata.Labels),
 					Annotations: tl.Spec.AdditionalMetadata.Annotations,
 				},
 				Spec: corev1.PodSpec{

--- a/internal/controller/chiawallet/assemblers.go
+++ b/internal/controller/chiawallet/assemblers.go
@@ -26,7 +26,7 @@ func (r *ChiaWalletReconciler) assembleBaseService(ctx context.Context, wallet k
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiawalletNamePattern, wallet.Name),
 			Namespace:       wallet.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, wallet.Kind, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels),
 			Annotations:     wallet.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, wallet),
 		},
@@ -52,7 +52,7 @@ func (r *ChiaWalletReconciler) assembleBaseService(ctx context.Context, wallet k
 					Name:       "rpc",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, wallet.Kind, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -63,7 +63,7 @@ func (r *ChiaWalletReconciler) assembleChiaExporterService(ctx context.Context, 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiawalletNamePattern, wallet.Name) + "-metrics",
 			Namespace:       wallet.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels, wallet.Spec.ChiaExporterConfig.ServiceLabels),
+			Labels:          kube.GetCommonLabels(ctx, wallet.Kind, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels, wallet.Spec.ChiaExporterConfig.ServiceLabels),
 			Annotations:     wallet.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, wallet),
 		},
@@ -77,7 +77,7 @@ func (r *ChiaWalletReconciler) assembleChiaExporterService(ctx context.Context, 
 					Name:       "metrics",
 				},
 			},
-			Selector: kube.GetCommonLabels(ctx, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels),
+			Selector: kube.GetCommonLabels(ctx, wallet.Kind, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels),
 		},
 	}
 }
@@ -88,17 +88,17 @@ func (r *ChiaWalletReconciler) assembleDeployment(ctx context.Context, wallet k8
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(chiawalletNamePattern, wallet.Name),
 			Namespace:       wallet.Namespace,
-			Labels:          kube.GetCommonLabels(ctx, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels),
+			Labels:          kube.GetCommonLabels(ctx, wallet.Kind, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels),
 			Annotations:     wallet.Spec.AdditionalMetadata.Annotations,
 			OwnerReferences: r.getOwnerReference(ctx, wallet),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: kube.GetCommonLabels(ctx, wallet.ObjectMeta),
+				MatchLabels: kube.GetCommonLabels(ctx, wallet.Kind, wallet.ObjectMeta),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      kube.GetCommonLabels(ctx, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels),
+					Labels:      kube.GetCommonLabels(ctx, wallet.Kind, wallet.ObjectMeta, wallet.Spec.AdditionalMetadata.Labels),
 					Annotations: wallet.Spec.AdditionalMetadata.Annotations,
 				},
 				Spec: corev1.PodSpec{

--- a/internal/controller/common/kube/helpers.go
+++ b/internal/controller/common/kube/helpers.go
@@ -6,6 +6,7 @@ package kube
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +16,7 @@ import (
 )
 
 // GetCommonLabels gives some common labels for chia-operator related objects
-func GetCommonLabels(ctx context.Context, meta metav1.ObjectMeta, additionalLabels ...map[string]string) map[string]string {
+func GetCommonLabels(ctx context.Context, kind string, meta metav1.ObjectMeta, additionalLabels ...map[string]string) map[string]string {
 	var labels = make(map[string]string)
 	for _, addition := range additionalLabels {
 		for k, v := range addition {
@@ -25,6 +26,7 @@ func GetCommonLabels(ctx context.Context, meta metav1.ObjectMeta, additionalLabe
 	labels["app.kubernetes.io/instance"] = meta.Name
 	labels["app.kubernetes.io/name"] = meta.Name
 	labels["app.kubernetes.io/managed-by"] = "chia-operator"
+	labels["k8s.chia.net/provenance"] = fmt.Sprintf("%s.%s.%s", kind, meta.Namespace, meta.Name)
 	return labels
 }
 


### PR DESCRIPTION
Problem:
If you're not very creative with your object names, you'll get into a state where the label selectors match nearly everything you deploy. Say if you deploy a ChiaNode and a ChiaFarmer with the name `mainnet`, the labels and selectors will all be the same. This provenance label guarantees a unique label to select, because it is in the format of `<Kind>.<namespace>.<name>`