### PR TITLE
Fix documentation lints and add CI linter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   release-manifests:
     runs-on: ubuntu-latest
+    container: ghcr.io/chia-network/build-images/ips:main
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -20,7 +21,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-go@v4
+      - name: Install kubectl
+        run: apk add kubectl
 
       - name: Generate release manifests
         run: make release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: actions/setup-go@v4
+
       - name: Generate release manifests
         run: make release
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,4 +80,5 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Lint Markdown'
+        # MD013 lints for long lines, ignoring because GitHub's markdown viewer wraps long lines anyway.
         run: markdownlint --disable=MD013 **/*.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,3 +66,18 @@ jobs:
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
+
+  markdown-lint:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/igorshubovych/markdownlint-cli:latest
+      options: --entrypoint /bin/sh
+    steps:
+      - name: 'Install deps'
+        run: apk add git
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+
+      - name: 'Lint Markdown'
+        run: markdownlint --disable=MD013 **/*.md

--- a/CONTIBUTING.md
+++ b/CONTIBUTING.md
@@ -1,14 +1,14 @@
-## Contributing
+# Contributing
 
-All commits should be signed using a key attached to your GitHub profile before creating a PR. 
+All commits should be signed using a key attached to your GitHub profile before creating a PR.
 
 When creating a pull request, have a clear summary of what the change does and why the change is useful. As an example of an acceptable PR message:
 
-```
+```markdown
 This pull request adds support for Chia Wallets. This would be useful for writing 3rd party apps to be deployed to kubernetes that need to communicate to a Chia wallet's RPCs.
 ```
 
-### API Contributions
+## API Contributions
 
 These rules/guidelines are meant to help keep a well defined style for accomplishing controller logic, and in some cases also helps persist controller-gen/kubebuilder defaults in comment tags because it can be easy to accidentally override the API default with a type's zero value on accident, for example.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,18 +1,21 @@
-### How it works
+# Development
+
+## How it works
+
 This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
 
 It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
 which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster.
 
-### Test It Out
+## Test It Out
 
-1. Install the CRDs into the cluster:
+Install the CRDs into the cluster:
 
 ```sh
 make install
 ```
 
-2. Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
+Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
 
 ```sh
 make run
@@ -20,7 +23,8 @@ make run
 
 **NOTE:** You can also run this in one step by running: `make install run`
 
-### Modifying the API definitions
+## Modifying the API definitions
+
 If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
 
 ```sh
@@ -31,14 +35,16 @@ make manifests
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 
-### Uninstall CRDs
+## Uninstall CRDs
+
 To delete the CRDs from the cluster:
 
 ```sh
 make uninstall
 ```
 
-### Undeploy controller
+## Undeploy controller
+
 UnDeploy the controller from the cluster:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # chia-operator
 
-NOTE: This should be considered a beta product. It is an early implementation that is being actively worked on. The API should stay backwards-compatible in the majority of cases but is not currently guaranteed.
+> NOTE: This is an early implementation that is being actively worked on. The API should stay backwards-compatible in the majority of cases but is not currently guaranteed.
 
 Kubernetes operator for managing Chia components in kubernetes. Currently supported components:
 
- - full_nodes
- - farmers
- - harvesters
- - wallets
- - timelords
+- full_nodes
+- farmers
+- harvesters
+- wallets
+- timelords
 
 Applying a CR for each component allows you to instantiate a configured instance of that component that is able to communicate to other requisite components in the cluster. A whole farm can be ran with each component isolated in its own pod, with a chia-exporter sidecar to scrape Prometheus metrics.
 
@@ -16,41 +16,22 @@ ChiaCA is an additional CRD that generates a certificate authority for Chia comp
 
 ## Getting Started
 
-
 ### Install the operator
 
-Clone this repository (and change to its directory):
-```bash
-git clone https://github.com/Chia-Network/chia-operator.git
-cd chia-operator
-```
-
-You're currently on the main branch which defaults to the latest versions of this operator, chia, and chia-exporter. You can switch to the latest release tag for a more stable experience:
-```bash
-git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
-```
-
-Install the CRDs:
-```bash
-make install
-```
-
-Deploy the operator:
-```bash
-make deploy
-```
-
-See the documentation for more in [docs](docs)
+[See the installation documentation.](docs/install.md)
 
 ### Start a farm
 
-This guide installs everything in the default namespace, but you can of course install them in any namespace. These are also all fairly minimal examples with just enough config to be helpful. Other options are supported. See the `config/samples` directory of this repo for more full examples.
+This guide installs everything in the default namespace, but you can of course install them in any namespace. These are also all fairly minimal examples with just enough config to be helpful. Other options are supported.
+
+[See the documentation for more information for configuring each of your chia resources.](docs)
 
 #### SSL CA
 
 First thing you'll need is a CA Secret. Chia components all communicate with each other over TLS with signed certificates all using the same certificate authority. This presents a problem in k8s, because each chia-docker container will try to generate their own CAs if none are declared, and all your components will refuse to communicate with each other. This operator contains a ChiaCA CRD that will generate a new CA and set it as a kubernetes Secret for you, or you can make your own Secret with a pre-existing ssl/ca directory. In this guide, we'll show the ChiaCA method first, and then the pre-made Secret second.
 
 Create a file named `ca.yaml`:
+
 ```yaml
 apiVersion: k8s.chia.net/v1
 kind: ChiaCA
@@ -63,6 +44,7 @@ spec:
 The `spec.secret` key specifies the name of the k8s Secret that will be created. The Secret will be created in the same namespace that the ChiaCA CR was created in. Apply this with `kubectl apply -f ca.yaml`
 
 The ChiaCA exists as an option of convenience, but if you have your own CA you'd like to use instead, you'll need to create a Secret that contains all the files in the `$CHIA_ROOT/config/ssl/ca` directory, like so:
+
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -79,11 +61,13 @@ data:
     <redacted base64'd file output>
 type: Opaque
 ```
+
 You only need to do this if you don't want to use the ChiaCA CR to make it for you.
 
 #### full_node
 
 Next we need a full_node. Create a file named `node.yaml`:
+
 ```yaml
 apiVersion: k8s.chia.net/v1
 kind: ChiaNode
@@ -103,6 +87,7 @@ spec:
 ```
 
 As you can see, we used a hostPath volume for CHIA_ROOT. We also specified a nodeSelector for the full_node pod that will be brought up in this Statefulset, this is because a hostPath won't move over to other nodes in the cluster if it gets scheduled elsewhere. You can configure a persistent volume claim instead. ChiaNode objects create StatefulSets which allow each pod to generate their very own PersistentVolumeClaim with this as your storage config:
+
 ```yaml
 storage:
   chiaRoot:
@@ -110,11 +95,13 @@ storage:
       storageClass: ""
       resourceRequest: "300Gi"
 ```
+
 Finally, apply your ChiaNode with: `kubectl apply -f node.yaml`
 
 #### farmer
 
 Now we can create a farmer that talks to our full_node. Create a file named `farmer.yaml`:
+
 ```yaml
 apiVersion: k8s.chia.net/v1
 kind: ChiaFarmer
@@ -129,9 +116,10 @@ spec:
       name: "chiakey"
       key: "key.txt"
 ```
+
 A couple of things going on here. First, we configured the fullNodePeer address, which we'll use kubernetes internal DNS names for services, targeting port 8444 on the `mainnet-node` service, in the `default` namespace, using the default cluster domain `cluster.local`. If your cluster uses a non-default domain name, switch it to that. Also switch `default` to whatever namespace your ChiaNode is deployed to.
 
-We also have a `secretKey` in the chia config spec. That defines a k8s Secret in the same namespace as this ChiaFarmer, named `chiakey` which contains one data key `key.txt` which contains your Chia mnemonic. 
+We also have a `secretKey` in the chia config spec. That defines a k8s Secret in the same namespace as this ChiaFarmer, named `chiakey` which contains one data key `key.txt` which contains your Chia mnemonic.
 
 Finally, apply this ChiaFarmer with `kubectl apply -f farmer.yaml`
 
@@ -179,7 +167,7 @@ spec:
       key: "key.txt"
 ```
 
-The config here is very similar to the farmer we already made since it also requires your mnemonic key and a full_node peer. 
+The config here is very similar to the farmer we already made since it also requires your mnemonic key and a full_node peer.
 
 Finally, apply this ChiaWallet with `kubectl apply -f wallet.yaml`
 
@@ -198,7 +186,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+```markdown
+http://www.apache.org/licenses/LICENSE-2.0
+```
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/docs/chiafarmer.md
+++ b/docs/chiafarmer.md
@@ -19,7 +19,7 @@ spec:
       key: "key.txt"
 ```
 
-### Chia configuration
+## Chia configuration
 
 Some of Chia's configuration can be changed from within the CR.
 
@@ -34,7 +34,6 @@ spec:
 ### CHIA_ROOT storage
 
 `CHIA_ROOT` is an environment variable that tells chia services where to expect a data directory to be for local chia state. You can store your chia state persistently a couple of different ways: either with a host mount or a persistent volume claim.
-
 
 To use a persistent volume claim, first create one in the same namespace and then give its name in the CR like the following:
 
@@ -66,7 +65,7 @@ spec:
 
 ### chia-exporter sidecar
 
-[chia-exporter](https://github.com/chia-network/chia-exporter) is a Prometheus exporter that surfaces scrape-able metrics to a Prometheus server. chia-exporter runs as a sidecar container to all Chia services ran by this operator by default. 
+[chia-exporter](https://github.com/chia-network/chia-exporter) is a Prometheus exporter that surfaces scrape-able metrics to a Prometheus server. chia-exporter runs as a sidecar container to all Chia services ran by this operator by default.
 
 #### Add labels to chia-exporter service
 

--- a/docs/chiaharvester.md
+++ b/docs/chiaharvester.md
@@ -15,7 +15,7 @@ spec:
     farmerAddress: "farmer.default.svc.cluster.local" # A local farmer using kubernetes DNS names
 ```
 
-### Chia configuration
+## Chia configuration
 
 Some of Chia's configuration can be changed from within the CR.
 
@@ -27,7 +27,7 @@ spec:
     logLevel: "INFO" # Sets the Chia log level.
 ```
 
-### Plot storage
+## Plot storage
 
 You can mount hostPath volumes or persistent volumes in a harvester pod using the following syntax. All claims/hostPaths get mounted as sub-directories of `/plots` in the container. Harvesters ran with this operator set the `recursive_plot_scan` option to true.
 
@@ -51,10 +51,9 @@ spec:
     kubernetes.io/hostname: "node-with-hostpath"
 ```
 
-### CHIA_ROOT storage
+## CHIA_ROOT storage
 
 `CHIA_ROOT` is an environment variable that tells chia services where to expect a data directory to be for local chia state. You can store your chia state persistently a couple of different ways: either with a host mount or a persistent volume claim.
-
 
 To use a persistent volume claim, first create one in the same namespace and then give its name in the CR like the following:
 
@@ -84,11 +83,11 @@ spec:
     kubernetes.io/hostname: "node-with-hostpath"
 ```
 
-### chia-exporter sidecar
+## chia-exporter sidecar
 
-[chia-exporter](https://github.com/chia-network/chia-exporter) is a Prometheus exporter that surfaces scrape-able metrics to a Prometheus server. chia-exporter runs as a sidecar container to all Chia services ran by this operator by default. 
+[chia-exporter](https://github.com/chia-network/chia-exporter) is a Prometheus exporter that surfaces scrape-able metrics to a Prometheus server. chia-exporter runs as a sidecar container to all Chia services ran by this operator by default.
 
-#### Add labels to chia-exporter service
+### Add labels to chia-exporter service
 
 You may want to add some labels to your chia-exporter Service that get added as labels to your Prometheus metrics.
 
@@ -99,7 +98,7 @@ spec:
       network: "mainnet"
 ```
 
-#### Disable chia-exporter
+### Disable chia-exporter
 
 ```yaml
 spec:
@@ -107,7 +106,7 @@ spec:
     enabled: false
 ```
 
-### Selecting a network
+## Selecting a network
 
 You can select a network from your chia configuration with the following options:
 
@@ -120,7 +119,7 @@ spec:
     dnsIntroducerAddress: "dns-introducer.default.svc.cluster.local" # Sets the DNS introducer address used in the chia config file.
 ```
 
-### Configure Readiness, Liveness, and Startup probes
+## Configure Readiness, Liveness, and Startup probes
 
 By default, if chia-exporter is enabled it comes with its own readiness and liveness probes. But you can configure readiness, liveness, and startup probes for the chia container in your deployed Pods, too:
 

--- a/docs/chianode.md
+++ b/docs/chianode.md
@@ -14,7 +14,7 @@ spec:
     caSecretName: chiaca-secret # A kubernetes Secret containing certificate authority files
 ```
 
-### Chia configuration
+## Chia configuration
 
 Some of Chia's configuration can be changed from within the CR.
 
@@ -26,10 +26,9 @@ spec:
     logLevel: "INFO" # Sets the Chia log level.
 ```
 
-### CHIA_ROOT storage
+## CHIA_ROOT storage
 
 `CHIA_ROOT` is an environment variable that tells chia services where to expect a data directory to be for local chia state. You can store your chia state persistently a couple of different ways: either with a host mount or a persistent volume claim.
-
 
 To use a persistent volume claim, first create one in the same namespace and then give its name in the CR like the following:
 
@@ -60,11 +59,11 @@ spec:
     kubernetes.io/hostname: "node-with-hostpath"
 ```
 
-### chia-exporter sidecar
+## chia-exporter sidecar
 
-[chia-exporter](https://github.com/chia-network/chia-exporter) is a Prometheus exporter that surfaces scrape-able metrics to a Prometheus server. chia-exporter runs as a sidecar container to all Chia services ran by this operator by default. 
+[chia-exporter](https://github.com/chia-network/chia-exporter) is a Prometheus exporter that surfaces scrape-able metrics to a Prometheus server. chia-exporter runs as a sidecar container to all Chia services ran by this operator by default.
 
-#### Add labels to chia-exporter service
+### Add labels to chia-exporter service
 
 You may want to add some labels to your chia-exporter Service that get added as labels to your Prometheus metrics.
 
@@ -75,7 +74,7 @@ spec:
       network: "mainnet"
 ```
 
-#### Disable chia-exporter
+### Disable chia-exporter
 
 ```yaml
 spec:
@@ -83,7 +82,7 @@ spec:
     enabled: false
 ```
 
-### Selecting a network
+## Selecting a network
 
 You can select a network from your chia configuration with the following options:
 
@@ -96,7 +95,7 @@ spec:
     dnsIntroducerAddress: "dns-introducer.default.svc.cluster.local" # Sets the DNS introducer address used in the chia config file.
 ```
 
-### Configure Readiness, Liveness, and Startup probes
+## Configure Readiness, Liveness, and Startup probes
 
 By default, if chia-exporter is enabled it comes with its own readiness and liveness probes. But you can configure readiness, liveness, and startup probes for the chia container in your deployed Pods, too:
 

--- a/docs/chianode.md
+++ b/docs/chianode.md
@@ -75,7 +75,6 @@ spec:
 ```
 
 ### Disable chia-exporter
-
 ```yaml
 spec:
   chiaExporter:

--- a/docs/chianode.md
+++ b/docs/chianode.md
@@ -75,6 +75,7 @@ spec:
 ```
 
 ### Disable chia-exporter
+
 ```yaml
 spec:
   chiaExporter:

--- a/docs/chiatimelord.md
+++ b/docs/chiatimelord.md
@@ -15,7 +15,7 @@ spec:
     fullNodePeer: "node.default.svc.cluster.local:8444" # A local full_node using kubernetes DNS names
 ```
 
-### Chia configuration
+## Chia configuration
 
 Some of Chia's configuration can be changed from within the CR.
 
@@ -27,10 +27,9 @@ spec:
     logLevel: "INFO" # Sets the Chia log level.
 ```
 
-### CHIA_ROOT storage
+## CHIA_ROOT storage
 
 `CHIA_ROOT` is an environment variable that tells chia services where to expect a data directory to be for local chia state. You can store your chia state persistently a couple of different ways: either with a host mount or a persistent volume claim.
-
 
 To use a persistent volume claim, first create one in the same namespace and then give its name in the CR like the following:
 
@@ -60,11 +59,11 @@ spec:
     kubernetes.io/hostname: "node-with-hostpath"
 ```
 
-### chia-exporter sidecar
+## chia-exporter sidecar
 
-[chia-exporter](https://github.com/chia-network/chia-exporter) is a Prometheus exporter that surfaces scrape-able metrics to a Prometheus server. chia-exporter runs as a sidecar container to all Chia services ran by this operator by default. 
+[chia-exporter](https://github.com/chia-network/chia-exporter) is a Prometheus exporter that surfaces scrape-able metrics to a Prometheus server. chia-exporter runs as a sidecar container to all Chia services ran by this operator by default.
 
-#### Add labels to chia-exporter service
+### Add labels to chia-exporter service
 
 You may want to add some labels to your chia-exporter Service that get added as labels to your Prometheus metrics.
 
@@ -75,7 +74,7 @@ spec:
       network: "mainnet"
 ```
 
-#### Disable chia-exporter
+### Disable chia-exporter
 
 ```yaml
 spec:
@@ -83,7 +82,7 @@ spec:
     enabled: false
 ```
 
-### Selecting a network
+## Selecting a network
 
 You can select a network from your chia configuration with the following options:
 
@@ -96,7 +95,7 @@ spec:
     dnsIntroducerAddress: "dns-introducer.default.svc.cluster.local" # Sets the DNS introducer address used in the chia config file.
 ```
 
-### Configure Readiness, Liveness, and Startup probes
+## Configure Readiness, Liveness, and Startup probes
 
 By default, if chia-exporter is enabled it comes with its own readiness and liveness probes. But you can configure readiness, liveness, and startup probes for the chia container in your deployed Pods, too:
 

--- a/docs/chiawallet.md
+++ b/docs/chiawallet.md
@@ -18,7 +18,7 @@ spec:
       key: "key.txt"
 ```
 
-### Chia configuration
+## Chia configuration
 
 Some of Chia's configuration can be changed from within the CR.
 
@@ -38,10 +38,9 @@ spec:
     fullNodePeer: "node.default.svc.cluster.local:8444" # A local full_node using kubernetes DNS names
 ```
 
-### CHIA_ROOT storage
+## CHIA_ROOT storage
 
 `CHIA_ROOT` is an environment variable that tells chia services where to expect a data directory to be for local chia state. You can store your chia state persistently a couple of different ways: either with a host mount or a persistent volume claim.
-
 
 To use a persistent volume claim, first create one in the same namespace and then give its name in the CR like the following:
 
@@ -71,11 +70,11 @@ spec:
     kubernetes.io/hostname: "node-with-hostpath"
 ```
 
-### chia-exporter sidecar
+## chia-exporter sidecar
 
-[chia-exporter](https://github.com/chia-network/chia-exporter) is a Prometheus exporter that surfaces scrape-able metrics to a Prometheus server. chia-exporter runs as a sidecar container to all Chia services ran by this operator by default. 
+[chia-exporter](https://github.com/chia-network/chia-exporter) is a Prometheus exporter that surfaces scrape-able metrics to a Prometheus server. chia-exporter runs as a sidecar container to all Chia services ran by this operator by default.
 
-#### Add labels to chia-exporter service
+### Add labels to chia-exporter service
 
 You may want to add some labels to your chia-exporter Service that get added as labels to your Prometheus metrics.
 
@@ -86,7 +85,7 @@ spec:
       network: "mainnet"
 ```
 
-#### Disable chia-exporter
+### Disable chia-exporter
 
 ```yaml
 spec:
@@ -94,7 +93,7 @@ spec:
     enabled: false
 ```
 
-### Selecting a network
+## Selecting a network
 
 You can select a network from your chia configuration with the following options:
 
@@ -107,7 +106,7 @@ spec:
     dnsIntroducerAddress: "dns-introducer.default.svc.cluster.local" # Sets the DNS introducer address used in the chia config file.
 ```
 
-### Configure Readiness, Liveness, and Startup probes
+## Configure Readiness, Liveness, and Startup probes
 
 By default, if chia-exporter is enabled it comes with its own readiness and liveness probes. But you can configure readiness, liveness, and startup probes for the chia container in your deployed Pods, too:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,9 +4,16 @@ There are two parts to this Operator. The CRDs (ChiaCA, ChiaFarmer, ChiaNode, et
 
 ## Using the release manifests
 
+Install the CRDs:
+
 ```bash
-kubectl apply -f 
-kubectl apply -f
+kubectl apply -f https://github.com/Chia-Network/chia-operator/releases/latest/download/crd.yaml
+```
+
+Install the controller manager:
+
+```bash
+kubectl apply -f https://github.com/Chia-Network/chia-operator/releases/latest/download/manager.yaml
 ```
 
 ## Using kustomize

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,37 @@
+# Installation
+
+There are two parts to this Operator. The CRDs (ChiaCA, ChiaFarmer, ChiaNode, etc) and the actual operator manager Deployment and related objects. You can install these components in two methods, either by cloning the repository and generating the manifests yourself with kustomize, or with `kubectl apply` on the generated manifests on all releases, starting with release `0.2.1`.
+
+## Using the release manifests
+
+```bash
+kubectl apply -f 
+kubectl apply -f
+```
+
+## Using kustomize
+
+Clone this repository (and change to its directory):
+
+```bash
+git clone https://github.com/Chia-Network/chia-operator.git
+cd chia-operator
+```
+
+You're currently on the main branch which defaults to the latest versions of this operator, chia, and chia-exporter. You can switch to the latest release tag for a more stable experience:
+
+```bash
+git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+```
+
+Install the CRDs:
+
+```bash
+make install
+```
+
+Deploy the operator:
+
+```bash
+make deploy
+```


### PR DESCRIPTION
Also adds a slight change to the release workflow to add dependencies that were missed in the original PR.

This closes https://github.com/Chia-Network/chia-operator/issues/48 by adding documentation on the kubectl installation using remote manifests on the latest releases.