### PR TITLE
Use github_workspace variable due to runner bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          FILES=$(find ${{ github.workspace }}/release -type f -name '*.yaml')
+          FILES=$(find ${GITHUB_WORKSPACE}/release -type f -name '*.yaml')
           while IFS= read -r file; do
             gh release upload \
               $RELEASE_TAG \


### PR DESCRIPTION
See: https://github.com/actions/runner/issues/2058

In containers, $GITHUB_WORKSPACE and github.workspace are two different values, though they should be the same. Using the former, which is allegedly correct inside containers.