### PR TITLE
Add containerPort to manager Deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,6 +59,8 @@ spec:
         - --leader-elect
         image: ghcr.io/chia-network/chia-operator:latest
         name: manager
+        ports:
+        - containerPort: 8081
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
Adding the containerPort to make it easier to create a Service and ServiceMonitor for chia-operator metrics