### PR TITLE
Add simple smoke tests for ChiaCA and ChiaNode

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,54 @@
+name: Smoke tests
+
+on: pull_request
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Install chia operator custom resources
+        run: |
+          make install
+
+      - name: Run the operator in the background
+        run: |
+          make run &
+
+      - name: Install chia components
+        run: |
+          kubectl apply -f ./config/samples/chiaca.yaml
+
+      - name: Wait for ChiaCA Secret
+        run: |
+          found=0
+          timeout=300
+          endtime=$((SECONDS+timeout))
+          while [ ${SECONDS} -lt ${endtime} ]; do
+            if kubectl get secret chiaca-secret &> /dev/null; then
+              echo "ChiaCA Secret found"
+              found=1
+              break
+            else
+              echo "Secret not found yet. Waiting..."
+              sleep 5
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "Timeout reached waiting for ChiaCA Secret to be created."
+            echo "Getting Kubernetes Pods from the default namespace:"
+            kubectl get pods
+            echo "Getting Kubernetes Secrets from the default namespace:"
+            kubectl get secrets
+            exit 1
+          fi

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install chia components
         run: |
           kubectl apply -f ./config/samples/chiaca.yaml
+          kubectl apply -f ./config/samples/chianode.yaml
 
       - name: Wait for ChiaCA Secret
         run: |
@@ -50,5 +51,34 @@ jobs:
             kubectl get pods
             echo "Getting Kubernetes Secrets from the default namespace:"
             kubectl get secrets
+            exit 1
+          fi
+
+      - name: Wait for Running ChiaNode
+        run: |
+          found=0
+          timeout=300
+          endtime=$((SECONDS+timeout))
+          while [ $SECONDS -lt $endtime ]; do
+            pod_status=$(kubectl get pod chianode-sample-node-0 -o jsonpath='{.status.phase}')
+            if [ "$pod_status" = "Running" ]; then
+              echo "Pod is running."
+              found=1
+              break  # Exit the loop if Pod is running
+            elif [ "$pod_status" = "Pending" ]; then
+              echo "Pod is pending. Waiting..."
+            elif [ "$pod_status" = "Failed" ] || [ "$pod_status" = "Unknown" ]; then
+              echo "Pod has failed or is in an unknown state. Exiting..."
+              exit 1
+            else
+              echo "Pod is in state: $pod_status. Waiting..."
+            fi
+            sleep 10
+          done
+          # Check if timeout was reached or if Pod is now up
+          if [ "$found" -eq 0 ]; then
+            echo "Timeout reached waiting for ChiaNode Pod to enter Running status."
+            echo "Getting Kubernetes Pods from the default namespace:"
+            kubectl get pods
             exit 1
           fi

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -73,7 +73,7 @@ jobs:
             else
               echo "Pod is in state: $pod_status. Waiting..."
             fi
-            sleep 10
+            sleep 5
           done
           # Check if timeout was reached or if Pod is now up
           if [ "$found" -eq 0 ]; then

--- a/config/samples/chianode.yaml
+++ b/config/samples/chianode.yaml
@@ -16,5 +16,6 @@ spec:
     logLevel: "INFO"
   storage:
     chiaRoot:
-      storageClass: ""
-      resourceRequest: "250Gi"
+      persistentVolumeClaim:
+        storageClass: "standard"
+        resourceRequest: "250Gi"


### PR DESCRIPTION
This PR aims to add smoke/e2e testing as part of https://github.com/Chia-Network/chia-operator/issues/35 though that issue is more about code testing, it was always the intent to do more e2e testing with a simple kubernetes cluster too. 