### PR TITLE
List IPv4 in docs first for pre-existing Services

### DIFF
--- a/docs/services-networking.md
+++ b/docs/services-networking.md
@@ -69,6 +69,6 @@ spec:
     peerService:
       ipFamilyPolicy: PreferDualStack
       ipFamilies:
-        - IPv6
         - IPv4
+        - IPv6
 ```


### PR DESCRIPTION
In Kubernetes if you try to apply a dual stack Service on top of what was a single stack Service (IPv4 vs IPv6) you need to list the pre-existing Stack in your Service config first. So the docs should list the default stack for Kubernetes ClusterIPs first for pre-existing users/Services.

This could possibly be worked around with a `get` query to the Service, to list the Service's current ClusterIPs, and force the operator to re-order the user-supplied IPFamilies list in the custom resource with whatever should be the first stack. But that's a fair amount of additional querying and logic to add. Hoping just listing them in this order in the docs keeps people from tripping up on this.