### PR TITLE
Set controller owners in a standardized way

### DIFF
--- a/internal/controller/chiaca/assemblers.go
+++ b/internal/controller/chiaca/assemblers.go
@@ -22,10 +22,9 @@ const chiacaNamePattern = "%s-chiaca-generator"
 func (r *ChiaCAReconciler) assembleJob(ca k8schianetv1.ChiaCA) batchv1.Job {
 	var job = batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf(chiacaNamePattern, ca.Name),
-			Namespace:       ca.Namespace,
-			Labels:          kube.GetCommonLabels(ca.Kind, ca.ObjectMeta),
-			OwnerReferences: getOwnerReference(ca),
+			Name:      fmt.Sprintf(chiacaNamePattern, ca.Name),
+			Namespace: ca.Namespace,
+			Labels:    kube.GetCommonLabels(ca.Kind, ca.ObjectMeta),
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
@@ -71,10 +70,9 @@ func (r *ChiaCAReconciler) assembleJob(ca k8schianetv1.ChiaCA) batchv1.Job {
 func (r *ChiaCAReconciler) assembleServiceAccount(ca k8schianetv1.ChiaCA) corev1.ServiceAccount {
 	return corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf(chiacaNamePattern, ca.Name),
-			Namespace:       ca.Namespace,
-			Labels:          kube.GetCommonLabels(ca.Kind, ca.ObjectMeta),
-			OwnerReferences: getOwnerReference(ca),
+			Name:      fmt.Sprintf(chiacaNamePattern, ca.Name),
+			Namespace: ca.Namespace,
+			Labels:    kube.GetCommonLabels(ca.Kind, ca.ObjectMeta),
 		},
 	}
 }
@@ -83,10 +81,9 @@ func (r *ChiaCAReconciler) assembleServiceAccount(ca k8schianetv1.ChiaCA) corev1
 func (r *ChiaCAReconciler) assembleRole(ca k8schianetv1.ChiaCA) rbacv1.Role {
 	return rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf(chiacaNamePattern, ca.Name),
-			Namespace:       ca.Namespace,
-			Labels:          kube.GetCommonLabels(ca.Kind, ca.ObjectMeta),
-			OwnerReferences: getOwnerReference(ca),
+			Name:      fmt.Sprintf(chiacaNamePattern, ca.Name),
+			Namespace: ca.Namespace,
+			Labels:    kube.GetCommonLabels(ca.Kind, ca.ObjectMeta),
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -108,10 +105,9 @@ func (r *ChiaCAReconciler) assembleRole(ca k8schianetv1.ChiaCA) rbacv1.Role {
 func (r *ChiaCAReconciler) assembleRoleBinding(ca k8schianetv1.ChiaCA) rbacv1.RoleBinding {
 	return rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf(chiacaNamePattern, ca.Name),
-			Namespace:       ca.Namespace,
-			Labels:          kube.GetCommonLabels(ca.Kind, ca.ObjectMeta),
-			OwnerReferences: getOwnerReference(ca),
+			Name:      fmt.Sprintf(chiacaNamePattern, ca.Name),
+			Namespace: ca.Namespace,
+			Labels:    kube.GetCommonLabels(ca.Kind, ca.ObjectMeta),
 		},
 		Subjects: []rbacv1.Subject{
 			{

--- a/internal/controller/chiaca/helpers.go
+++ b/internal/controller/chiaca/helpers.go
@@ -9,11 +9,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
-	"github.com/chia-network/chia-operator/internal/controller/common/consts"
 )
 
 // getCASecret fetches the k8s Secret that matches this ChiaCA deployment. Returns Secret, boolean, and error (if any).
@@ -32,17 +30,4 @@ func (r *ChiaCAReconciler) getCASecret(ctx context.Context, ca k8schianetv1.Chia
 	}
 
 	return caSecret, false, nil
-}
-
-// getOwnerReference gives the common owner reference spec for ChiaCA related objects
-func getOwnerReference(ca k8schianetv1.ChiaCA) []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		{
-			APIVersion: ca.APIVersion,
-			Kind:       ca.Kind,
-			Name:       ca.Name,
-			UID:        ca.UID,
-			Controller: &consts.ControllerOwner,
-		},
-	}
 }

--- a/internal/controller/chiacrawler/assemblers.go
+++ b/internal/controller/chiacrawler/assemblers.go
@@ -23,9 +23,8 @@ const chiacrawlerNamePattern = "%s-crawler"
 // assemblePeerService assembles the peer Service resource for a ChiaCrawler CR
 func assemblePeerService(crawler k8schianetv1.ChiaCrawler) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiacrawlerNamePattern, crawler.Name),
-		Namespace:      crawler.Namespace,
-		OwnerReference: getOwnerReference(crawler),
+		Name:      fmt.Sprintf(chiacrawlerNamePattern, crawler.Name),
+		Namespace: crawler.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       getFullNodePort(crawler),
@@ -61,10 +60,9 @@ func assemblePeerService(crawler k8schianetv1.ChiaCrawler) corev1.Service {
 // assembleDaemonService assembles the daemon Service resource for a ChiaCrawler CR
 func assembleDaemonService(crawler k8schianetv1.ChiaCrawler) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiacrawlerNamePattern, crawler.Name) + "-daemon",
-		Namespace:      crawler.Namespace,
-		OwnerReference: getOwnerReference(crawler),
-		Ports:          kube.GetChiaDaemonServicePorts(),
+		Name:      fmt.Sprintf(chiacrawlerNamePattern, crawler.Name) + "-daemon",
+		Namespace: crawler.Namespace,
+		Ports:     kube.GetChiaDaemonServicePorts(),
 	}
 
 	inputs.ServiceType = crawler.Spec.ChiaConfig.DaemonService.ServiceType
@@ -92,9 +90,8 @@ func assembleDaemonService(crawler k8schianetv1.ChiaCrawler) corev1.Service {
 // assembleRPCService assembles the RPC Service resource for a ChiaCrawler CR
 func assembleRPCService(crawler k8schianetv1.ChiaCrawler) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiacrawlerNamePattern, crawler.Name) + "-rpc",
-		Namespace:      crawler.Namespace,
-		OwnerReference: getOwnerReference(crawler),
+		Name:      fmt.Sprintf(chiacrawlerNamePattern, crawler.Name) + "-rpc",
+		Namespace: crawler.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.CrawlerRPCPort,
@@ -130,10 +127,9 @@ func assembleRPCService(crawler k8schianetv1.ChiaCrawler) corev1.Service {
 // assembleChiaExporterService assembles the chia-exporter Service resource for a ChiaCrawler CR
 func assembleChiaExporterService(crawler k8schianetv1.ChiaCrawler) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiacrawlerNamePattern, crawler.Name) + "-metrics",
-		Namespace:      crawler.Namespace,
-		OwnerReference: getOwnerReference(crawler),
-		Ports:          kube.GetChiaExporterServicePorts(),
+		Name:      fmt.Sprintf(chiacrawlerNamePattern, crawler.Name) + "-metrics",
+		Namespace: crawler.Namespace,
+		Ports:     kube.GetChiaExporterServicePorts(),
 	}
 
 	inputs.ServiceType = crawler.Spec.ChiaExporterConfig.Service.ServiceType

--- a/internal/controller/chiacrawler/helpers.go
+++ b/internal/controller/chiacrawler/helpers.go
@@ -7,7 +7,6 @@ package chiacrawler
 import (
 	"fmt"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
 
 	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
@@ -186,19 +185,6 @@ func getChiaEnv(crawler k8schianetv1.ChiaCrawler) []corev1.EnvVar {
 	}
 
 	return env
-}
-
-// getOwnerReference gives the common owner reference spec for ChiaCrawler related objects
-func getOwnerReference(crawler k8schianetv1.ChiaCrawler) []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		{
-			APIVersion: crawler.APIVersion,
-			Kind:       crawler.Kind,
-			Name:       crawler.Name,
-			UID:        crawler.UID,
-			Controller: &consts.ControllerOwner,
-		},
-	}
 }
 
 // getFullNodePort determines the correct full_node port to use

--- a/internal/controller/chiafarmer/assemblers.go
+++ b/internal/controller/chiafarmer/assemblers.go
@@ -23,9 +23,8 @@ const chiafarmerNamePattern = "%s-farmer"
 // assemblePeerService assembles the peer Service resource for a ChiaFarmer CR
 func assemblePeerService(farmer k8schianetv1.ChiaFarmer) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiafarmerNamePattern, farmer.Name),
-		Namespace:      farmer.Namespace,
-		OwnerReference: getOwnerReference(farmer),
+		Name:      fmt.Sprintf(chiafarmerNamePattern, farmer.Name),
+		Namespace: farmer.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.FarmerPort,
@@ -61,10 +60,9 @@ func assemblePeerService(farmer k8schianetv1.ChiaFarmer) corev1.Service {
 // assembleDaemonService assembles the daemon Service resource for a ChiaFarmer CR
 func assembleDaemonService(farmer k8schianetv1.ChiaFarmer) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiafarmerNamePattern, farmer.Name) + "-daemon",
-		Namespace:      farmer.Namespace,
-		OwnerReference: getOwnerReference(farmer),
-		Ports:          kube.GetChiaDaemonServicePorts(),
+		Name:      fmt.Sprintf(chiafarmerNamePattern, farmer.Name) + "-daemon",
+		Namespace: farmer.Namespace,
+		Ports:     kube.GetChiaDaemonServicePorts(),
 	}
 
 	inputs.ServiceType = farmer.Spec.ChiaConfig.DaemonService.ServiceType
@@ -92,9 +90,8 @@ func assembleDaemonService(farmer k8schianetv1.ChiaFarmer) corev1.Service {
 // assembleRPCService assembles the RPC Service resource for a ChiaFarmer CR
 func assembleRPCService(farmer k8schianetv1.ChiaFarmer) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiafarmerNamePattern, farmer.Name) + "-rpc",
-		Namespace:      farmer.Namespace,
-		OwnerReference: getOwnerReference(farmer),
+		Name:      fmt.Sprintf(chiafarmerNamePattern, farmer.Name) + "-rpc",
+		Namespace: farmer.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.FarmerRPCPort,
@@ -130,10 +127,9 @@ func assembleRPCService(farmer k8schianetv1.ChiaFarmer) corev1.Service {
 // assembleChiaExporterService assembles the chia-exporter Service resource for a ChiaFarmer CR
 func assembleChiaExporterService(farmer k8schianetv1.ChiaFarmer) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiafarmerNamePattern, farmer.Name) + "-metrics",
-		Namespace:      farmer.Namespace,
-		OwnerReference: getOwnerReference(farmer),
-		Ports:          kube.GetChiaExporterServicePorts(),
+		Name:      fmt.Sprintf(chiafarmerNamePattern, farmer.Name) + "-metrics",
+		Namespace: farmer.Namespace,
+		Ports:     kube.GetChiaExporterServicePorts(),
 	}
 
 	inputs.ServiceType = farmer.Spec.ChiaExporterConfig.Service.ServiceType

--- a/internal/controller/chiafarmer/controller.go
+++ b/internal/controller/chiafarmer/controller.go
@@ -8,16 +8,14 @@ import (
 	"context"
 	"fmt"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -77,6 +75,9 @@ func (r *ChiaFarmerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Reconcile ChiaFarmer owned objects
 	if kube.ShouldMakeService(farmer.Spec.ChiaConfig.PeerService) {
 		srv := assemblePeerService(farmer)
+		if err := controllerutil.SetControllerReference(&farmer, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -107,6 +108,9 @@ func (r *ChiaFarmerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if kube.ShouldMakeService(farmer.Spec.ChiaConfig.DaemonService) {
 		srv := assembleDaemonService(farmer)
+		if err := controllerutil.SetControllerReference(&farmer, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -139,6 +143,9 @@ func (r *ChiaFarmerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if kube.ShouldMakeService(farmer.Spec.ChiaConfig.RPCService) {
 		srv := assembleRPCService(farmer)
+		if err := controllerutil.SetControllerReference(&farmer, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -171,6 +178,9 @@ func (r *ChiaFarmerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if kube.ShouldMakeService(farmer.Spec.ChiaExporterConfig.Service) {
 		srv := assembleChiaExporterService(farmer)
+		if err := controllerutil.SetControllerReference(&farmer, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -255,39 +265,6 @@ func (r *ChiaFarmerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8schianetv1.ChiaFarmer{}).
 		Owns(&appsv1.Deployment{}).
-		Watches(
-			&corev1.Service{},
-			handler.EnqueueRequestsFromMapFunc(r.findObjectsForService),
-		).
+		Owns(&corev1.Service{}).
 		Complete(r)
-}
-
-// findObjectsForService since we get an event for any changes to every Service in the cluster,
-// this lists the Chia custom resource this controller manages in the same namespace as the Service, and then
-// checks if this Service has an OwnerReference to any of the Chia custom resources returned in the list,
-// and sends a reconcile request for the resource this Service was owned by, if any
-func (r *ChiaFarmerReconciler) findObjectsForService(ctx context.Context, obj client.Object) []reconcile.Request {
-	listOps := &client.ListOptions{
-		Namespace: obj.GetNamespace(),
-	}
-	list := &k8schianetv1.ChiaFarmerList{}
-	err := r.List(ctx, list, listOps)
-	if err != nil {
-		return []reconcile.Request{}
-	}
-
-	requests := make([]reconcile.Request, len(list.Items))
-	for i, item := range list.Items {
-		for _, ref := range obj.GetOwnerReferences() {
-			if ref.Kind == item.Kind && ref.Name == item.GetName() {
-				requests[i] = reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      item.GetName(),
-						Namespace: item.GetNamespace(),
-					},
-				}
-			}
-		}
-	}
-	return requests
 }

--- a/internal/controller/chiafarmer/helpers.go
+++ b/internal/controller/chiafarmer/helpers.go
@@ -8,11 +8,8 @@ import (
 	"fmt"
 	"strconv"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
-	"github.com/chia-network/chia-operator/internal/controller/common/consts"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // getChiaVolumes retrieves the requisite volumes from the Chia config struct
@@ -198,17 +195,4 @@ func getChiaEnv(farmer k8schianetv1.ChiaFarmer) []corev1.EnvVar {
 	})
 
 	return env
-}
-
-// getOwnerReference gives the common owner reference spec for ChiaFarmer related objects
-func getOwnerReference(farmer k8schianetv1.ChiaFarmer) []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		{
-			APIVersion: farmer.APIVersion,
-			Kind:       farmer.Kind,
-			Name:       farmer.Name,
-			UID:        farmer.UID,
-			Controller: &consts.ControllerOwner,
-		},
-	}
 }

--- a/internal/controller/chiaharvester/assemblers.go
+++ b/internal/controller/chiaharvester/assemblers.go
@@ -23,9 +23,8 @@ const chiaharvesterNamePattern = "%s-harvester"
 // assemblePeerService assembles the peer Service resource for a ChiaHarvester CR
 func assemblePeerService(harvester k8schianetv1.ChiaHarvester) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaharvesterNamePattern, harvester.Name),
-		Namespace:      harvester.Namespace,
-		OwnerReference: getOwnerReference(harvester),
+		Name:      fmt.Sprintf(chiaharvesterNamePattern, harvester.Name),
+		Namespace: harvester.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.HarvesterPort,
@@ -61,10 +60,9 @@ func assemblePeerService(harvester k8schianetv1.ChiaHarvester) corev1.Service {
 // assembleDaemonService assembles the daemon Service resource for a ChiaHarvester CR
 func assembleDaemonService(harvester k8schianetv1.ChiaHarvester) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaharvesterNamePattern, harvester.Name) + "-daemon",
-		Namespace:      harvester.Namespace,
-		OwnerReference: getOwnerReference(harvester),
-		Ports:          kube.GetChiaDaemonServicePorts(),
+		Name:      fmt.Sprintf(chiaharvesterNamePattern, harvester.Name) + "-daemon",
+		Namespace: harvester.Namespace,
+		Ports:     kube.GetChiaDaemonServicePorts(),
 	}
 
 	inputs.ServiceType = harvester.Spec.ChiaConfig.DaemonService.ServiceType
@@ -92,9 +90,8 @@ func assembleDaemonService(harvester k8schianetv1.ChiaHarvester) corev1.Service 
 // assembleRPCService assembles the RPC Service resource for a ChiaHarvester CR
 func assembleRPCService(harvester k8schianetv1.ChiaHarvester) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaharvesterNamePattern, harvester.Name) + "-rpc",
-		Namespace:      harvester.Namespace,
-		OwnerReference: getOwnerReference(harvester),
+		Name:      fmt.Sprintf(chiaharvesterNamePattern, harvester.Name) + "-rpc",
+		Namespace: harvester.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.HarvesterRPCPort,
@@ -130,10 +127,9 @@ func assembleRPCService(harvester k8schianetv1.ChiaHarvester) corev1.Service {
 // assembleChiaExporterService assembles the chia-exporter Service resource for a ChiaHarvester CR
 func assembleChiaExporterService(harvester k8schianetv1.ChiaHarvester) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaharvesterNamePattern, harvester.Name) + "-metrics",
-		Namespace:      harvester.Namespace,
-		OwnerReference: getOwnerReference(harvester),
-		Ports:          kube.GetChiaExporterServicePorts(),
+		Name:      fmt.Sprintf(chiaharvesterNamePattern, harvester.Name) + "-metrics",
+		Namespace: harvester.Namespace,
+		Ports:     kube.GetChiaExporterServicePorts(),
 	}
 
 	inputs.ServiceType = harvester.Spec.ChiaExporterConfig.Service.ServiceType

--- a/internal/controller/chiaharvester/controller.go
+++ b/internal/controller/chiaharvester/controller.go
@@ -8,16 +8,14 @@ import (
 	"context"
 	"fmt"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -77,6 +75,9 @@ func (r *ChiaHarvesterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Reconcile ChiaHarvester owned objects
 	if kube.ShouldMakeService(harvester.Spec.ChiaConfig.PeerService) {
 		srv := assemblePeerService(harvester)
+		if err := controllerutil.SetControllerReference(&harvester, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -107,6 +108,9 @@ func (r *ChiaHarvesterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if kube.ShouldMakeService(harvester.Spec.ChiaConfig.DaemonService) {
 		srv := assembleDaemonService(harvester)
+		if err := controllerutil.SetControllerReference(&harvester, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -139,6 +143,9 @@ func (r *ChiaHarvesterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if kube.ShouldMakeService(harvester.Spec.ChiaConfig.RPCService) {
 		srv := assembleRPCService(harvester)
+		if err := controllerutil.SetControllerReference(&harvester, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -171,6 +178,9 @@ func (r *ChiaHarvesterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if kube.ShouldMakeService(harvester.Spec.ChiaExporterConfig.Service) {
 		srv := assembleChiaExporterService(harvester)
+		if err := controllerutil.SetControllerReference(&harvester, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -255,39 +265,6 @@ func (r *ChiaHarvesterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8schianetv1.ChiaHarvester{}).
 		Owns(&appsv1.Deployment{}).
-		Watches(
-			&corev1.Service{},
-			handler.EnqueueRequestsFromMapFunc(r.findObjectsForService),
-		).
+		Owns(&corev1.Service{}).
 		Complete(r)
-}
-
-// findObjectsForService since we get an event for any changes to every Service in the cluster,
-// this lists the Chia custom resource this controller manages in the same namespace as the Service, and then
-// checks if this Service has an OwnerReference to any of the Chia custom resources returned in the list,
-// and sends a reconcile request for the resource this Service was owned by, if any
-func (r *ChiaHarvesterReconciler) findObjectsForService(ctx context.Context, obj client.Object) []reconcile.Request {
-	listOps := &client.ListOptions{
-		Namespace: obj.GetNamespace(),
-	}
-	list := &k8schianetv1.ChiaHarvesterList{}
-	err := r.List(ctx, list, listOps)
-	if err != nil {
-		return []reconcile.Request{}
-	}
-
-	requests := make([]reconcile.Request, len(list.Items))
-	for i, item := range list.Items {
-		for _, ref := range obj.GetOwnerReferences() {
-			if ref.Kind == item.Kind && ref.Name == item.GetName() {
-				requests[i] = reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      item.GetName(),
-						Namespace: item.GetNamespace(),
-					},
-				}
-			}
-		}
-	}
-	return requests
 }

--- a/internal/controller/chiaharvester/helpers.go
+++ b/internal/controller/chiaharvester/helpers.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 	"strconv"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
 	"github.com/chia-network/chia-operator/internal/controller/common/consts"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // getChiaVolumes retrieves the requisite volumes from the Chia config struct
@@ -262,17 +260,4 @@ func getChiaEnv(harvester k8schianetv1.ChiaHarvester) []corev1.EnvVar {
 	})
 
 	return env
-}
-
-// getOwnerReference gives the common owner reference spec for ChiaHarvester related objects
-func getOwnerReference(harvester k8schianetv1.ChiaHarvester) []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		{
-			APIVersion: harvester.APIVersion,
-			Kind:       harvester.Kind,
-			Name:       harvester.Name,
-			UID:        harvester.UID,
-			Controller: &consts.ControllerOwner,
-		},
-	}
 }

--- a/internal/controller/chiaintroducer/assemblers.go
+++ b/internal/controller/chiaintroducer/assemblers.go
@@ -23,9 +23,8 @@ const chiaintroducerNamePattern = "%s-introducer"
 // assemblePeerService assembles the peer Service resource for a ChiaIntroducer CR
 func assemblePeerService(introducer k8schianetv1.ChiaIntroducer) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaintroducerNamePattern, introducer.Name),
-		Namespace:      introducer.Namespace,
-		OwnerReference: getOwnerReference(introducer),
+		Name:      fmt.Sprintf(chiaintroducerNamePattern, introducer.Name),
+		Namespace: introducer.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       getFullNodePort(introducer),
@@ -61,10 +60,9 @@ func assemblePeerService(introducer k8schianetv1.ChiaIntroducer) corev1.Service 
 // assembleDaemonService assembles the daemon Service resource for a ChiaIntroducer CR
 func assembleDaemonService(introducer k8schianetv1.ChiaIntroducer) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaintroducerNamePattern, introducer.Name) + "-daemon",
-		Namespace:      introducer.Namespace,
-		OwnerReference: getOwnerReference(introducer),
-		Ports:          kube.GetChiaDaemonServicePorts(),
+		Name:      fmt.Sprintf(chiaintroducerNamePattern, introducer.Name) + "-daemon",
+		Namespace: introducer.Namespace,
+		Ports:     kube.GetChiaDaemonServicePorts(),
 	}
 
 	inputs.ServiceType = introducer.Spec.ChiaConfig.DaemonService.ServiceType
@@ -92,10 +90,9 @@ func assembleDaemonService(introducer k8schianetv1.ChiaIntroducer) corev1.Servic
 // assembleChiaExporterService assembles the chia-exporter Service resource for a ChiaIntroducer CR
 func assembleChiaExporterService(introducer k8schianetv1.ChiaIntroducer) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaintroducerNamePattern, introducer.Name) + "-metrics",
-		Namespace:      introducer.Namespace,
-		OwnerReference: getOwnerReference(introducer),
-		Ports:          kube.GetChiaExporterServicePorts(),
+		Name:      fmt.Sprintf(chiaintroducerNamePattern, introducer.Name) + "-metrics",
+		Namespace: introducer.Namespace,
+		Ports:     kube.GetChiaExporterServicePorts(),
 	}
 
 	inputs.ServiceType = introducer.Spec.ChiaExporterConfig.Service.ServiceType

--- a/internal/controller/chiaintroducer/helpers.go
+++ b/internal/controller/chiaintroducer/helpers.go
@@ -7,7 +7,6 @@ package chiaintroducer
 import (
 	"fmt"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
 
 	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
@@ -193,19 +192,6 @@ func getChiaEnv(introducer k8schianetv1.ChiaIntroducer) []corev1.EnvVar {
 	}
 
 	return env
-}
-
-// getOwnerReference gives the common owner reference spec for ChiaIntroducer related objects
-func getOwnerReference(introducer k8schianetv1.ChiaIntroducer) []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		{
-			APIVersion: introducer.APIVersion,
-			Kind:       introducer.Kind,
-			Name:       introducer.Name,
-			UID:        introducer.UID,
-			Controller: &consts.ControllerOwner,
-		},
-	}
 }
 
 // getFullNodePort determines the correct full_node port to use

--- a/internal/controller/chianode/assemblers.go
+++ b/internal/controller/chianode/assemblers.go
@@ -23,9 +23,8 @@ const chianodeNamePattern = "%s-node"
 // assemblePeerService assembles the peer Service resource for a ChiaNode CR
 func assemblePeerService(node k8schianetv1.ChiaNode) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chianodeNamePattern, node.Name),
-		Namespace:      node.Namespace,
-		OwnerReference: getOwnerReference(node),
+		Name:      fmt.Sprintf(chianodeNamePattern, node.Name),
+		Namespace: node.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       getFullNodePort(node),
@@ -61,10 +60,9 @@ func assemblePeerService(node k8schianetv1.ChiaNode) corev1.Service {
 // assembleDaemonService assembles the daemon Service resource for a ChiaNode CR
 func assembleDaemonService(node k8schianetv1.ChiaNode) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chianodeNamePattern, node.Name) + "-daemon",
-		Namespace:      node.Namespace,
-		OwnerReference: getOwnerReference(node),
-		Ports:          kube.GetChiaDaemonServicePorts(),
+		Name:      fmt.Sprintf(chianodeNamePattern, node.Name) + "-daemon",
+		Namespace: node.Namespace,
+		Ports:     kube.GetChiaDaemonServicePorts(),
 	}
 
 	inputs.ServiceType = node.Spec.ChiaConfig.DaemonService.ServiceType
@@ -92,9 +90,8 @@ func assembleDaemonService(node k8schianetv1.ChiaNode) corev1.Service {
 // assembleRPCService assembles the RPC Service resource for a ChiaNode CR
 func assembleRPCService(node k8schianetv1.ChiaNode) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chianodeNamePattern, node.Name) + "-rpc",
-		Namespace:      node.Namespace,
-		OwnerReference: getOwnerReference(node),
+		Name:      fmt.Sprintf(chianodeNamePattern, node.Name) + "-rpc",
+		Namespace: node.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.NodeRPCPort,
@@ -130,10 +127,9 @@ func assembleRPCService(node k8schianetv1.ChiaNode) corev1.Service {
 // assembleChiaExporterService assembles the chia-exporter Service resource for a ChiaNode CR
 func assembleChiaExporterService(node k8schianetv1.ChiaNode) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chianodeNamePattern, node.Name) + "-metrics",
-		Namespace:      node.Namespace,
-		OwnerReference: getOwnerReference(node),
-		Ports:          kube.GetChiaExporterServicePorts(),
+		Name:      fmt.Sprintf(chianodeNamePattern, node.Name) + "-metrics",
+		Namespace: node.Namespace,
+		Ports:     kube.GetChiaExporterServicePorts(),
 	}
 
 	inputs.ServiceType = node.Spec.ChiaExporterConfig.Service.ServiceType
@@ -161,10 +157,9 @@ func assembleChiaExporterService(node k8schianetv1.ChiaNode) corev1.Service {
 // assembleChiaHealthcheckService assembles the chia-healthcheck Service resource for a ChiaNode CR
 func assembleChiaHealthcheckService(node k8schianetv1.ChiaNode) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chianodeNamePattern, node.Name) + "-healthcheck",
-		Namespace:      node.Namespace,
-		OwnerReference: getOwnerReference(node),
-		Ports:          kube.GetChiaHealthcheckServicePorts(),
+		Name:      fmt.Sprintf(chianodeNamePattern, node.Name) + "-healthcheck",
+		Namespace: node.Namespace,
+		Ports:     kube.GetChiaHealthcheckServicePorts(),
 	}
 
 	inputs.ServiceType = node.Spec.ChiaHealthcheckConfig.Service.ServiceType

--- a/internal/controller/chianode/helpers.go
+++ b/internal/controller/chianode/helpers.go
@@ -210,19 +210,6 @@ func getChiaEnv(ctx context.Context, node k8schianetv1.ChiaNode) []corev1.EnvVar
 	return env
 }
 
-// getOwnerReference gives the common owner reference spec for ChiaNode related objects
-func getOwnerReference(node k8schianetv1.ChiaNode) []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		{
-			APIVersion: node.APIVersion,
-			Kind:       node.Kind,
-			Name:       node.Name,
-			UID:        node.UID,
-			Controller: &consts.ControllerOwner,
-		},
-	}
-}
-
 // getFullNodePort determines the correct full node port to use
 func getFullNodePort(node k8schianetv1.ChiaNode) int32 {
 	if node.Spec.ChiaConfig.Testnet != nil && *node.Spec.ChiaConfig.Testnet {

--- a/internal/controller/chiaseeder/assemblers.go
+++ b/internal/controller/chiaseeder/assemblers.go
@@ -23,9 +23,8 @@ const chiaseederNamePattern = "%s-seeder"
 // assemblePeerService assembles the peer Service resource for a ChiaSeeder CR
 func assemblePeerService(seeder k8schianetv1.ChiaSeeder) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaseederNamePattern, seeder.Name),
-		Namespace:      seeder.Namespace,
-		OwnerReference: getOwnerReference(seeder),
+		Name:      fmt.Sprintf(chiaseederNamePattern, seeder.Name),
+		Namespace: seeder.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       53,
@@ -73,10 +72,9 @@ func assemblePeerService(seeder k8schianetv1.ChiaSeeder) corev1.Service {
 // assembleDaemonService assembles the daemon Service resource for a ChiaSeeder CR
 func assembleDaemonService(seeder k8schianetv1.ChiaSeeder) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaseederNamePattern, seeder.Name) + "-daemon",
-		Namespace:      seeder.Namespace,
-		OwnerReference: getOwnerReference(seeder),
-		Ports:          kube.GetChiaDaemonServicePorts(),
+		Name:      fmt.Sprintf(chiaseederNamePattern, seeder.Name) + "-daemon",
+		Namespace: seeder.Namespace,
+		Ports:     kube.GetChiaDaemonServicePorts(),
 	}
 
 	inputs.ServiceType = seeder.Spec.ChiaConfig.DaemonService.ServiceType
@@ -104,9 +102,8 @@ func assembleDaemonService(seeder k8schianetv1.ChiaSeeder) corev1.Service {
 // assembleRPCService assembles the RPC Service resource for a ChiaSeeder CR
 func assembleRPCService(seeder k8schianetv1.ChiaSeeder) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaseederNamePattern, seeder.Name) + "-rpc",
-		Namespace:      seeder.Namespace,
-		OwnerReference: getOwnerReference(seeder),
+		Name:      fmt.Sprintf(chiaseederNamePattern, seeder.Name) + "-rpc",
+		Namespace: seeder.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.CrawlerRPCPort,
@@ -142,10 +139,9 @@ func assembleRPCService(seeder k8schianetv1.ChiaSeeder) corev1.Service {
 // assembleChiaExporterService assembles the chia-exporter Service resource for a ChiaSeeder CR
 func assembleChiaExporterService(seeder k8schianetv1.ChiaSeeder) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaseederNamePattern, seeder.Name) + "-metrics",
-		Namespace:      seeder.Namespace,
-		OwnerReference: getOwnerReference(seeder),
-		Ports:          kube.GetChiaExporterServicePorts(),
+		Name:      fmt.Sprintf(chiaseederNamePattern, seeder.Name) + "-metrics",
+		Namespace: seeder.Namespace,
+		Ports:     kube.GetChiaExporterServicePorts(),
 	}
 
 	inputs.ServiceType = seeder.Spec.ChiaExporterConfig.Service.ServiceType
@@ -173,10 +169,9 @@ func assembleChiaExporterService(seeder k8schianetv1.ChiaSeeder) corev1.Service 
 // assembleChiaHealthcheckService assembles the chia-healthcheck Service resource for a ChiaSeeder CR
 func assembleChiaHealthcheckService(seeder k8schianetv1.ChiaSeeder) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiaseederNamePattern, seeder.Name) + "-healthcheck",
-		Namespace:      seeder.Namespace,
-		OwnerReference: getOwnerReference(seeder),
-		Ports:          kube.GetChiaHealthcheckServicePorts(),
+		Name:      fmt.Sprintf(chiaseederNamePattern, seeder.Name) + "-healthcheck",
+		Namespace: seeder.Namespace,
+		Ports:     kube.GetChiaHealthcheckServicePorts(),
 	}
 
 	inputs.ServiceType = seeder.Spec.ChiaHealthcheckConfig.Service.ServiceType

--- a/internal/controller/chiaseeder/helpers.go
+++ b/internal/controller/chiaseeder/helpers.go
@@ -7,7 +7,6 @@ package chiaseeder
 import (
 	"fmt"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
 
 	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
@@ -228,19 +227,6 @@ func getChiaEnv(seeder k8schianetv1.ChiaSeeder) []corev1.EnvVar {
 	}
 
 	return env
-}
-
-// getOwnerReference gives the common owner reference spec for ChiaSeeder related objects
-func getOwnerReference(seeder k8schianetv1.ChiaSeeder) []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		{
-			APIVersion: seeder.APIVersion,
-			Kind:       seeder.Kind,
-			Name:       seeder.Name,
-			UID:        seeder.UID,
-			Controller: &consts.ControllerOwner,
-		},
-	}
 }
 
 // getFullNodePort determines the correct full_node port to use

--- a/internal/controller/chiatimelord/assemblers.go
+++ b/internal/controller/chiatimelord/assemblers.go
@@ -23,9 +23,8 @@ const chiatimelordNamePattern = "%s-timelord"
 // assemblePeerService assembles the peer Service resource for a ChiaTimelord CR
 func assemblePeerService(tl k8schianetv1.ChiaTimelord) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiatimelordNamePattern, tl.Name),
-		Namespace:      tl.Namespace,
-		OwnerReference: getOwnerReference(tl),
+		Name:      fmt.Sprintf(chiatimelordNamePattern, tl.Name),
+		Namespace: tl.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.TimelordPort,
@@ -61,10 +60,9 @@ func assemblePeerService(tl k8schianetv1.ChiaTimelord) corev1.Service {
 // assembleDaemonService assembles the daemon Service resource for a ChiaTimelord CR
 func assembleDaemonService(tl k8schianetv1.ChiaTimelord) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiatimelordNamePattern, tl.Name) + "-daemon",
-		Namespace:      tl.Namespace,
-		OwnerReference: getOwnerReference(tl),
-		Ports:          kube.GetChiaDaemonServicePorts(),
+		Name:      fmt.Sprintf(chiatimelordNamePattern, tl.Name) + "-daemon",
+		Namespace: tl.Namespace,
+		Ports:     kube.GetChiaDaemonServicePorts(),
 	}
 
 	inputs.ServiceType = tl.Spec.ChiaConfig.DaemonService.ServiceType
@@ -92,9 +90,8 @@ func assembleDaemonService(tl k8schianetv1.ChiaTimelord) corev1.Service {
 // assembleRPCService assembles the RPC Service resource for a ChiaTimelord CR
 func assembleRPCService(tl k8schianetv1.ChiaTimelord) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiatimelordNamePattern, tl.Name) + "-rpc",
-		Namespace:      tl.Namespace,
-		OwnerReference: getOwnerReference(tl),
+		Name:      fmt.Sprintf(chiatimelordNamePattern, tl.Name) + "-rpc",
+		Namespace: tl.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.TimelordRPCPort,
@@ -130,10 +127,9 @@ func assembleRPCService(tl k8schianetv1.ChiaTimelord) corev1.Service {
 // assembleChiaExporterService assembles the chia-exporter Service resource for a ChiaTimelord CR
 func assembleChiaExporterService(tl k8schianetv1.ChiaTimelord) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiatimelordNamePattern, tl.Name) + "-metrics",
-		Namespace:      tl.Namespace,
-		OwnerReference: getOwnerReference(tl),
-		Ports:          kube.GetChiaExporterServicePorts(),
+		Name:      fmt.Sprintf(chiatimelordNamePattern, tl.Name) + "-metrics",
+		Namespace: tl.Namespace,
+		Ports:     kube.GetChiaExporterServicePorts(),
 	}
 
 	inputs.ServiceType = tl.Spec.ChiaExporterConfig.Service.ServiceType

--- a/internal/controller/chiatimelord/controller.go
+++ b/internal/controller/chiatimelord/controller.go
@@ -8,16 +8,14 @@ import (
 	"context"
 	"fmt"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -77,6 +75,9 @@ func (r *ChiaTimelordReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Reconcile ChiaTimelord owned objects
 	if kube.ShouldMakeService(tl.Spec.ChiaConfig.PeerService) {
 		srv := assemblePeerService(tl)
+		if err := controllerutil.SetControllerReference(&tl, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -107,6 +108,9 @@ func (r *ChiaTimelordReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if kube.ShouldMakeService(tl.Spec.ChiaConfig.DaemonService) {
 		srv := assembleDaemonService(tl)
+		if err := controllerutil.SetControllerReference(&tl, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -139,6 +143,9 @@ func (r *ChiaTimelordReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if kube.ShouldMakeService(tl.Spec.ChiaConfig.RPCService) {
 		srv := assembleRPCService(tl)
+		if err := controllerutil.SetControllerReference(&tl, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -171,6 +178,9 @@ func (r *ChiaTimelordReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if kube.ShouldMakeService(tl.Spec.ChiaExporterConfig.Service) {
 		srv := assembleChiaExporterService(tl)
+		if err := controllerutil.SetControllerReference(&tl, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -255,39 +265,6 @@ func (r *ChiaTimelordReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8schianetv1.ChiaTimelord{}).
 		Owns(&appsv1.Deployment{}).
-		Watches(
-			&corev1.Service{},
-			handler.EnqueueRequestsFromMapFunc(r.findObjectsForService),
-		).
+		Owns(&corev1.Service{}).
 		Complete(r)
-}
-
-// findObjectsForService since we get an event for any changes to every Service in the cluster,
-// this lists the Chia custom resource this controller manages in the same namespace as the Service, and then
-// checks if this Service has an OwnerReference to any of the Chia custom resources returned in the list,
-// and sends a reconcile request for the resource this Service was owned by, if any
-func (r *ChiaTimelordReconciler) findObjectsForService(ctx context.Context, obj client.Object) []reconcile.Request {
-	listOps := &client.ListOptions{
-		Namespace: obj.GetNamespace(),
-	}
-	list := &k8schianetv1.ChiaTimelordList{}
-	err := r.List(ctx, list, listOps)
-	if err != nil {
-		return []reconcile.Request{}
-	}
-
-	requests := make([]reconcile.Request, len(list.Items))
-	for i, item := range list.Items {
-		for _, ref := range obj.GetOwnerReferences() {
-			if ref.Kind == item.Kind && ref.Name == item.GetName() {
-				requests[i] = reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      item.GetName(),
-						Namespace: item.GetNamespace(),
-					},
-				}
-			}
-		}
-	}
-	return requests
 }

--- a/internal/controller/chiatimelord/helpers.go
+++ b/internal/controller/chiatimelord/helpers.go
@@ -8,11 +8,8 @@ import (
 	"fmt"
 	"strconv"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
-	"github.com/chia-network/chia-operator/internal/controller/common/consts"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // getChiaVolumes retrieves the requisite volumes from the Chia config struct
@@ -178,17 +175,4 @@ func getChiaEnv(tl k8schianetv1.ChiaTimelord) []corev1.EnvVar {
 	})
 
 	return env
-}
-
-// getOwnerReference gives the common owner reference spec for ChiaTimelord related objects
-func getOwnerReference(tl k8schianetv1.ChiaTimelord) []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		{
-			APIVersion: tl.APIVersion,
-			Kind:       tl.Kind,
-			Name:       tl.Name,
-			UID:        tl.UID,
-			Controller: &consts.ControllerOwner,
-		},
-	}
 }

--- a/internal/controller/chiawallet/assemblers.go
+++ b/internal/controller/chiawallet/assemblers.go
@@ -23,9 +23,8 @@ const chiawalletNamePattern = "%s-wallet"
 // assemblePeerService assembles the peer Service resource for a ChiaWallet CR
 func assemblePeerService(wallet k8schianetv1.ChiaWallet) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiawalletNamePattern, wallet.Name),
-		Namespace:      wallet.Namespace,
-		OwnerReference: getOwnerReference(wallet),
+		Name:      fmt.Sprintf(chiawalletNamePattern, wallet.Name),
+		Namespace: wallet.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.WalletPort,
@@ -61,10 +60,9 @@ func assemblePeerService(wallet k8schianetv1.ChiaWallet) corev1.Service {
 // assembleDaemonService assembles the daemon Service resource for a ChiaWallet CR
 func assembleDaemonService(wallet k8schianetv1.ChiaWallet) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiawalletNamePattern, wallet.Name) + "-daemon",
-		Namespace:      wallet.Namespace,
-		OwnerReference: getOwnerReference(wallet),
-		Ports:          kube.GetChiaDaemonServicePorts(),
+		Name:      fmt.Sprintf(chiawalletNamePattern, wallet.Name) + "-daemon",
+		Namespace: wallet.Namespace,
+		Ports:     kube.GetChiaDaemonServicePorts(),
 	}
 
 	inputs.ServiceType = wallet.Spec.ChiaConfig.DaemonService.ServiceType
@@ -92,9 +90,8 @@ func assembleDaemonService(wallet k8schianetv1.ChiaWallet) corev1.Service {
 // assembleRPCService assembles the RPC Service resource for a ChiaWallet CR
 func assembleRPCService(wallet k8schianetv1.ChiaWallet) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiawalletNamePattern, wallet.Name) + "-rpc",
-		Namespace:      wallet.Namespace,
-		OwnerReference: getOwnerReference(wallet),
+		Name:      fmt.Sprintf(chiawalletNamePattern, wallet.Name) + "-rpc",
+		Namespace: wallet.Namespace,
 		Ports: []corev1.ServicePort{
 			{
 				Port:       consts.WalletRPCPort,
@@ -130,10 +127,9 @@ func assembleRPCService(wallet k8schianetv1.ChiaWallet) corev1.Service {
 // assembleChiaExporterService assembles the chia-exporter Service resource for a ChiaWallet CR
 func assembleChiaExporterService(wallet k8schianetv1.ChiaWallet) corev1.Service {
 	inputs := kube.AssembleCommonServiceInputs{
-		Name:           fmt.Sprintf(chiawalletNamePattern, wallet.Name) + "-metrics",
-		Namespace:      wallet.Namespace,
-		OwnerReference: getOwnerReference(wallet),
-		Ports:          kube.GetChiaExporterServicePorts(),
+		Name:      fmt.Sprintf(chiawalletNamePattern, wallet.Name) + "-metrics",
+		Namespace: wallet.Namespace,
+		Ports:     kube.GetChiaExporterServicePorts(),
 	}
 
 	inputs.ServiceType = wallet.Spec.ChiaExporterConfig.Service.ServiceType

--- a/internal/controller/chiawallet/controller.go
+++ b/internal/controller/chiawallet/controller.go
@@ -8,16 +8,14 @@ import (
 	"context"
 	"fmt"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -77,6 +75,9 @@ func (r *ChiaWalletReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Reconcile ChiaWallet owned objects
 	if kube.ShouldMakeService(wallet.Spec.ChiaConfig.PeerService) {
 		srv := assemblePeerService(wallet)
+		if err := controllerutil.SetControllerReference(&wallet, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -107,6 +108,9 @@ func (r *ChiaWalletReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if kube.ShouldMakeService(wallet.Spec.ChiaConfig.DaemonService) {
 		srv := assembleDaemonService(wallet)
+		if err := controllerutil.SetControllerReference(&wallet, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -139,6 +143,9 @@ func (r *ChiaWalletReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if kube.ShouldMakeService(wallet.Spec.ChiaConfig.RPCService) {
 		srv := assembleRPCService(wallet)
+		if err := controllerutil.SetControllerReference(&wallet, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -171,6 +178,9 @@ func (r *ChiaWalletReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if kube.ShouldMakeService(wallet.Spec.ChiaExporterConfig.Service) {
 		srv := assembleChiaExporterService(wallet)
+		if err := controllerutil.SetControllerReference(&wallet, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
 		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
 		if err != nil {
 			if res == nil {
@@ -255,39 +265,6 @@ func (r *ChiaWalletReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8schianetv1.ChiaWallet{}).
 		Owns(&appsv1.Deployment{}).
-		Watches(
-			&corev1.Service{},
-			handler.EnqueueRequestsFromMapFunc(r.findObjectsForService),
-		).
+		Owns(&corev1.Service{}).
 		Complete(r)
-}
-
-// findObjectsForService since we get an event for any changes to every Service in the cluster,
-// this lists the Chia custom resource this controller manages in the same namespace as the Service, and then
-// checks if this Service has an OwnerReference to any of the Chia custom resources returned in the list,
-// and sends a reconcile request for the resource this Service was owned by, if any
-func (r *ChiaWalletReconciler) findObjectsForService(ctx context.Context, obj client.Object) []reconcile.Request {
-	listOps := &client.ListOptions{
-		Namespace: obj.GetNamespace(),
-	}
-	list := &k8schianetv1.ChiaWalletList{}
-	err := r.List(ctx, list, listOps)
-	if err != nil {
-		return []reconcile.Request{}
-	}
-
-	requests := make([]reconcile.Request, len(list.Items))
-	for i, item := range list.Items {
-		for _, ref := range obj.GetOwnerReferences() {
-			if ref.Kind == item.Kind && ref.Name == item.GetName() {
-				requests[i] = reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      item.GetName(),
-						Namespace: item.GetNamespace(),
-					},
-				}
-			}
-		}
-	}
-	return requests
 }

--- a/internal/controller/chiawallet/helpers.go
+++ b/internal/controller/chiawallet/helpers.go
@@ -11,11 +11,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"strconv"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
 	"github.com/chia-network/chia-operator/internal/controller/common/consts"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // getChiaPorts returns the ports to a chia container
@@ -238,17 +236,4 @@ func getChiaEnv(ctx context.Context, wallet k8schianetv1.ChiaWallet) []corev1.En
 	}
 
 	return env
-}
-
-// getOwnerReference gives the common owner reference spec for ChiaWallet related objects
-func getOwnerReference(wallet k8schianetv1.ChiaWallet) []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		{
-			APIVersion: wallet.APIVersion,
-			Kind:       wallet.Kind,
-			Name:       wallet.Name,
-			UID:        wallet.UID,
-			Controller: &consts.ControllerOwner,
-		},
-	}
 }

--- a/internal/controller/common/consts/consts.go
+++ b/internal/controller/common/consts/consts.go
@@ -4,9 +4,6 @@ Copyright 2023 Chia Network Inc.
 
 package consts
 
-// ControllerOwner bool to help set the controller owner for a create kubernetes Kind
-var ControllerOwner = true
-
 // ChiaKind enumerates the list of Chia component custom resources this operator controls
 type ChiaKind string
 

--- a/internal/controller/common/kube/assemblers_test.go
+++ b/internal/controller/common/kube/assemblers_test.go
@@ -11,6 +11,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+var testControllerOwner = true
+
 func TestAssembleCommonService_Minimal(t *testing.T) {
 	expected := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -28,7 +30,7 @@ func TestAssembleCommonService_Minimal(t *testing.T) {
 					Kind:       "ChiaTest",
 					Name:       "test",
 					UID:        "testuid",
-					Controller: &consts.ControllerOwner,
+					Controller: &testControllerOwner,
 				},
 			},
 		},
@@ -76,7 +78,7 @@ func TestAssembleCommonService_Full(t *testing.T) {
 					Kind:       "ChiaTest",
 					Name:       "test",
 					UID:        "testuid",
-					Controller: &consts.ControllerOwner,
+					Controller: &testControllerOwner,
 				},
 			},
 		},


### PR DESCRIPTION
Previously there was custom logic to set and watch controller owned resources. This does it in a standardized way requiring less duplicative logic.