### PR TITLE
Support setting the self_hostname configuration parameter

### DIFF
--- a/api/v1/chiacommon_types.go
+++ b/api/v1/chiacommon_types.go
@@ -106,6 +106,11 @@ type CommonSpecChia struct {
 	// +optional
 	LogLevel *string `json:"logLevel,omitempty"`
 
+	// SelfHostname defines the bind address of chia services in the container
+	// Setting to `0.0.0.0` binds chia services to all interfaces
+	// +optional
+	SelfHostname *string `json:"selfHostname,omitempty"`
+
 	// PeerService defines settings for the default Service installed with any Chia component resource.
 	// This Service usually contains ports for peer connections, or in the case of seeders port 53.
 	// This Service will default to being enabled with a ClusterIP Service type.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1227,6 +1227,11 @@ func (in *CommonSpecChia) DeepCopyInto(out *CommonSpecChia) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SelfHostname != nil {
+		in, out := &in.SelfHostname, &out.SelfHostname
+		*out = new(string)
+		**out = **in
+	}
 	in.PeerService.DeepCopyInto(&out.PeerService)
 	in.DaemonService.DeepCopyInto(&out.DaemonService)
 	in.RPCService.DeepCopyInto(&out.RPCService)

--- a/config/crd/bases/k8s.chia.net_chiacrawlers.yaml
+++ b/config/crd/bases/k8s.chia.net_chiacrawlers.yaml
@@ -1691,6 +1691,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  selfHostname:
+                    description: |-
+                      SelfHostname defines the bind address of chia services in the container
+                      Setting to `0.0.0.0` binds chia services to all interfaces
+                    type: string
                   startupProbe:
                     description: StartupProbe indicates that the Pod has successfully
                       initialized.

--- a/config/crd/bases/k8s.chia.net_chiafarmers.yaml
+++ b/config/crd/bases/k8s.chia.net_chiafarmers.yaml
@@ -1711,6 +1711,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  selfHostname:
+                    description: |-
+                      SelfHostname defines the bind address of chia services in the container
+                      Setting to `0.0.0.0` binds chia services to all interfaces
+                    type: string
                   startupProbe:
                     description: StartupProbe indicates that the Pod has successfully
                       initialized.

--- a/config/crd/bases/k8s.chia.net_chiaharvesters.yaml
+++ b/config/crd/bases/k8s.chia.net_chiaharvesters.yaml
@@ -1696,6 +1696,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  selfHostname:
+                    description: |-
+                      SelfHostname defines the bind address of chia services in the container
+                      Setting to `0.0.0.0` binds chia services to all interfaces
+                    type: string
                   startupProbe:
                     description: StartupProbe indicates that the Pod has successfully
                       initialized.

--- a/config/crd/bases/k8s.chia.net_chiaintroducers.yaml
+++ b/config/crd/bases/k8s.chia.net_chiaintroducers.yaml
@@ -1691,6 +1691,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  selfHostname:
+                    description: |-
+                      SelfHostname defines the bind address of chia services in the container
+                      Setting to `0.0.0.0` binds chia services to all interfaces
+                    type: string
                   startupProbe:
                     description: StartupProbe indicates that the Pod has successfully
                       initialized.

--- a/config/crd/bases/k8s.chia.net_chianodes.yaml
+++ b/config/crd/bases/k8s.chia.net_chianodes.yaml
@@ -1691,6 +1691,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  selfHostname:
+                    description: |-
+                      SelfHostname defines the bind address of chia services in the container
+                      Setting to `0.0.0.0` binds chia services to all interfaces
+                    type: string
                   startupProbe:
                     description: StartupProbe indicates that the Pod has successfully
                       initialized.

--- a/config/crd/bases/k8s.chia.net_chiaseeders.yaml
+++ b/config/crd/bases/k8s.chia.net_chiaseeders.yaml
@@ -1712,6 +1712,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  selfHostname:
+                    description: |-
+                      SelfHostname defines the bind address of chia services in the container
+                      Setting to `0.0.0.0` binds chia services to all interfaces
+                    type: string
                   startupProbe:
                     description: StartupProbe indicates that the Pod has successfully
                       initialized.

--- a/config/crd/bases/k8s.chia.net_chiatimelords.yaml
+++ b/config/crd/bases/k8s.chia.net_chiatimelords.yaml
@@ -1696,6 +1696,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  selfHostname:
+                    description: |-
+                      SelfHostname defines the bind address of chia services in the container
+                      Setting to `0.0.0.0` binds chia services to all interfaces
+                    type: string
                   startupProbe:
                     description: StartupProbe indicates that the Pod has successfully
                       initialized.

--- a/config/crd/bases/k8s.chia.net_chiawallets.yaml
+++ b/config/crd/bases/k8s.chia.net_chiawallets.yaml
@@ -1711,6 +1711,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  selfHostname:
+                    description: |-
+                      SelfHostname defines the bind address of chia services in the container
+                      Setting to `0.0.0.0` binds chia services to all interfaces
+                    type: string
                   startupProbe:
                     description: StartupProbe indicates that the Pod has successfully
                       initialized.

--- a/docs/all.md
+++ b/docs/all.md
@@ -12,6 +12,7 @@ spec:
     testnet: true # Switches to the default testnet in the Chia configuration file.
     timezone: "UTC" # Switches the tzdata timezone in the container.
     logLevel: "INFO" # Sets the Chia log level.
+    selfHostname: "0.0.0.0" # Sets the self_hostname setting in the config, which affects what network interfaces chia services are bound to.
 ```
 
 ### Selecting a network

--- a/internal/controller/chiacrawler/helpers.go
+++ b/internal/controller/chiacrawler/helpers.go
@@ -184,6 +184,14 @@ func getChiaEnv(crawler k8schianetv1.ChiaCrawler) []corev1.EnvVar {
 		})
 	}
 
+	// self_hostname env var
+	if crawler.Spec.ChiaConfig.SelfHostname != nil {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: *crawler.Spec.ChiaConfig.SelfHostname,
+		})
+	}
+
 	return env
 }
 

--- a/internal/controller/chiafarmer/helpers.go
+++ b/internal/controller/chiafarmer/helpers.go
@@ -182,6 +182,14 @@ func getChiaEnv(farmer k8schianetv1.ChiaFarmer) []corev1.EnvVar {
 		})
 	}
 
+	// self_hostname env var
+	if farmer.Spec.ChiaConfig.SelfHostname != nil {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: *farmer.Spec.ChiaConfig.SelfHostname,
+		})
+	}
+
 	// keys env var
 	env = append(env, corev1.EnvVar{
 		Name:  "keys",

--- a/internal/controller/chiaharvester/helpers.go
+++ b/internal/controller/chiaharvester/helpers.go
@@ -242,6 +242,14 @@ func getChiaEnv(harvester k8schianetv1.ChiaHarvester) []corev1.EnvVar {
 		})
 	}
 
+	// self_hostname env var
+	if harvester.Spec.ChiaConfig.SelfHostname != nil {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: *harvester.Spec.ChiaConfig.SelfHostname,
+		})
+	}
+
 	// recursive_plot_scan env var -- needed because all plot drives are just mounted as subdirs under `/plots`.
 	// TODO make plot mount paths configurable -- make this var optional
 	env = append(env, corev1.EnvVar{

--- a/internal/controller/chiaintroducer/helpers.go
+++ b/internal/controller/chiaintroducer/helpers.go
@@ -191,6 +191,14 @@ func getChiaEnv(introducer k8schianetv1.ChiaIntroducer) []corev1.EnvVar {
 		})
 	}
 
+	// self_hostname env var
+	if introducer.Spec.ChiaConfig.SelfHostname != nil {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: *introducer.Spec.ChiaConfig.SelfHostname,
+		})
+	}
+
 	return env
 }
 

--- a/internal/controller/chianode/helpers.go
+++ b/internal/controller/chianode/helpers.go
@@ -207,6 +207,14 @@ func getChiaEnv(ctx context.Context, node k8schianetv1.ChiaNode) []corev1.EnvVar
 		})
 	}
 
+	// self_hostname env var
+	if node.Spec.ChiaConfig.SelfHostname != nil {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: *node.Spec.ChiaConfig.SelfHostname,
+		})
+	}
+
 	return env
 }
 

--- a/internal/controller/chiaseeder/helpers.go
+++ b/internal/controller/chiaseeder/helpers.go
@@ -184,6 +184,14 @@ func getChiaEnv(seeder k8schianetv1.ChiaSeeder) []corev1.EnvVar {
 		})
 	}
 
+	// self_hostname env var
+	if seeder.Spec.ChiaConfig.SelfHostname != nil {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: *seeder.Spec.ChiaConfig.SelfHostname,
+		})
+	}
+
 	// seeder_bootstrap_peers env var
 	if seeder.Spec.ChiaConfig.BootstrapPeer != nil {
 		env = append(env, corev1.EnvVar{

--- a/internal/controller/chiatimelord/helpers.go
+++ b/internal/controller/chiatimelord/helpers.go
@@ -168,6 +168,14 @@ func getChiaEnv(tl k8schianetv1.ChiaTimelord) []corev1.EnvVar {
 		})
 	}
 
+	// self_hostname env var
+	if tl.Spec.ChiaConfig.SelfHostname != nil {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: *tl.Spec.ChiaConfig.SelfHostname,
+		})
+	}
+
 	// node peer env var
 	env = append(env, corev1.EnvVar{
 		Name:  "full_node_peer",

--- a/internal/controller/chiawallet/helpers.go
+++ b/internal/controller/chiawallet/helpers.go
@@ -221,6 +221,14 @@ func getChiaEnv(ctx context.Context, wallet k8schianetv1.ChiaWallet) []corev1.En
 		})
 	}
 
+	// self_hostname env var
+	if wallet.Spec.ChiaConfig.SelfHostname != nil {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: *wallet.Spec.ChiaConfig.SelfHostname,
+		})
+	}
+
 	// keys env var
 	env = append(env, corev1.EnvVar{
 		Name:  "keys",


### PR DESCRIPTION
For https://github.com/Chia-Network/chia-operator/issues/122

This keeps the default to 127.0.0.1 for self_hostname, but exposes it as an option to the user.