### PR TITLE
Build ca generating image in smoke test job

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1
+        with:
+          cluster_name: kind # the action defaults to "chart-testing" which causes the load command below to fail
 
       - name: Load CA gen image
         run: kind load docker-image cagentest:1

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,8 +11,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Build ca-gen
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          tags: cagentest:1
+          context: chiaca-generator/
+          file: chiaca-generator/Dockerfile
+
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1
+
+      - name: Load CA gen image
+        run: kind load docker-image cagentest:1
 
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
@@ -27,8 +38,8 @@ jobs:
 
       - name: Install chia components
         run: |
-          kubectl apply -f ./config/samples/chiaca.yaml
-          kubectl apply -f ./config/samples/chianode.yaml
+          kubectl apply -f ./tests/chiaca.yaml
+          kubectl apply -f ./tests/chianode.yaml
 
       - name: Wait for ChiaCA Secret
         run: |
@@ -60,7 +71,7 @@ jobs:
           timeout=300
           endtime=$((SECONDS+timeout))
           while [ $SECONDS -lt $endtime ]; do
-            pod_status=$(kubectl get pod chianode-sample-node-0 -o jsonpath='{.status.phase}')
+            pod_status=$(kubectl get pod chianode-test-node-0 -o jsonpath='{.status.phase}')
             if [ "$pod_status" = "Running" ]; then
               echo "Pod is running."
               found=1
@@ -85,7 +96,7 @@ jobs:
 
       - name: Check to make sure ChiaNode peer Service has one endpoint
         run: |
-          service_endpoints_number=$(kubectl get endpoints chianode-sample-node -o json | jq '.subsets[].addresses | length')
+          service_endpoints_number=$(kubectl get endpoints chianode-test-node -o json | jq '.subsets[].addresses | length')
           if [ "$service_endpoints_number" -ne 1 ]; then
             echo "ChiaNode peer Service was found to have $service_endpoints_number endpoints, expected 1"
             exit 1
@@ -94,7 +105,7 @@ jobs:
 
       - name: Check to make sure ChiaNode RPC Service has one endpoint
         run: |
-          service_endpoints_number=$(kubectl get endpoints chianode-sample-node-rpc -o json | jq '.subsets[].addresses | length')
+          service_endpoints_number=$(kubectl get endpoints chianode-test-node-rpc -o json | jq '.subsets[].addresses | length')
           if [ "$service_endpoints_number" -ne 1 ]; then
             echo "ChiaNode RPC Service was found to have $service_endpoints_number endpoints, expected 1"
             exit 1
@@ -103,7 +114,7 @@ jobs:
 
       - name: Check to make sure ChiaNode daemon Service has one endpoint
         run: |
-          service_endpoints_number=$(kubectl get endpoints chianode-sample-node-daemon -o json | jq '.subsets[].addresses | length')
+          service_endpoints_number=$(kubectl get endpoints chianode-test-node-daemon -o json | jq '.subsets[].addresses | length')
           if [ "$service_endpoints_number" -ne 1 ]; then
             echo "ChiaNode daemon Service was found to have $service_endpoints_number endpoints, expected 1"
             exit 1
@@ -112,7 +123,7 @@ jobs:
 
       - name: Check to make sure ChiaNode headless Service has one endpoint
         run: |
-          service_endpoints_number=$(kubectl get endpoints chianode-sample-node-headless -o json | jq '.subsets[].addresses | length')
+          service_endpoints_number=$(kubectl get endpoints chianode-test-node-headless -o json | jq '.subsets[].addresses | length')
           if [ "$service_endpoints_number" -ne 1 ]; then
             echo "ChiaNode headless Service was found to have $service_endpoints_number endpoints, expected 1"
             exit 1
@@ -121,7 +132,7 @@ jobs:
 
       - name: Check to make sure ChiaNode internal Service has one endpoint
         run: |
-          service_endpoints_number=$(kubectl get endpoints chianode-sample-node-internal -o json | jq '.subsets[].addresses | length')
+          service_endpoints_number=$(kubectl get endpoints chianode-test-node-internal -o json | jq '.subsets[].addresses | length')
           if [ "$service_endpoints_number" -ne 1 ]; then
             echo "ChiaNode internal Service was found to have $service_endpoints_number endpoints, expected 1"
             exit 1

--- a/tests/chiaca.yaml
+++ b/tests/chiaca.yaml
@@ -1,0 +1,7 @@
+apiVersion: k8s.chia.net/v1
+kind: ChiaCA
+metadata:
+  name: chiaca-test
+spec:
+  image: cagentest:1
+  secret: chiaca-secret

--- a/tests/chianode.yaml
+++ b/tests/chianode.yaml
@@ -1,0 +1,16 @@
+apiVersion: k8s.chia.net/v1
+kind: ChiaNode
+metadata:
+  name: chianode-test
+spec:
+  replicas: 1
+  chia:
+    caSecretName: chiaca-secret
+    testnet: true
+    timezone: "UTC"
+    logLevel: "INFO"
+  storage:
+    chiaRoot:
+      persistentVolumeClaim:
+        storageClass: "standard"
+        resourceRequest: "250Gi"


### PR DESCRIPTION
This should allow this test to run in release-context workflows where the default CA generator image is set to a tag that will only be created after the release is made, after the pull request has already been merged. So these smoke tests currently always fail in a release context PR.