### PR TITLE
Default self_hostname to 0.0.0.0

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -12,7 +12,7 @@ spec:
     testnet: true # Switches to the default testnet in the Chia configuration file.
     timezone: "UTC" # Switches the tzdata timezone in the container.
     logLevel: "INFO" # Sets the Chia log level.
-    selfHostname: "0.0.0.0" # Sets the self_hostname setting in the config, which affects what network interfaces chia services are bound to.
+    selfHostname: "127.0.0.1" # Sets the self_hostname setting in the config, which affects what network interfaces chia services are bound to (defaults to 0.0.0.0) 
 ```
 
 ### Selecting a network

--- a/internal/controller/chiacrawler/helpers.go
+++ b/internal/controller/chiacrawler/helpers.go
@@ -189,6 +189,11 @@ func getChiaEnv(crawler k8schianetv1.ChiaCrawler) []corev1.EnvVar {
 			Name:  "self_hostname",
 			Value: *crawler.Spec.ChiaConfig.SelfHostname,
 		})
+	} else {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: "0.0.0.0",
+		})
 	}
 
 	return env

--- a/internal/controller/chiafarmer/helpers.go
+++ b/internal/controller/chiafarmer/helpers.go
@@ -188,6 +188,11 @@ func getChiaEnv(farmer k8schianetv1.ChiaFarmer) []corev1.EnvVar {
 			Name:  "self_hostname",
 			Value: *farmer.Spec.ChiaConfig.SelfHostname,
 		})
+	} else {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: "0.0.0.0",
+		})
 	}
 
 	// keys env var

--- a/internal/controller/chiaharvester/helpers.go
+++ b/internal/controller/chiaharvester/helpers.go
@@ -248,6 +248,11 @@ func getChiaEnv(harvester k8schianetv1.ChiaHarvester) []corev1.EnvVar {
 			Name:  "self_hostname",
 			Value: *harvester.Spec.ChiaConfig.SelfHostname,
 		})
+	} else {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: "0.0.0.0",
+		})
 	}
 
 	// recursive_plot_scan env var -- needed because all plot drives are just mounted as subdirs under `/plots`.

--- a/internal/controller/chiaintroducer/helpers.go
+++ b/internal/controller/chiaintroducer/helpers.go
@@ -191,6 +191,11 @@ func getChiaEnv(introducer k8schianetv1.ChiaIntroducer) []corev1.EnvVar {
 			Name:  "self_hostname",
 			Value: *introducer.Spec.ChiaConfig.SelfHostname,
 		})
+	} else {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: "0.0.0.0",
+		})
 	}
 
 	return env

--- a/internal/controller/chianode/helpers.go
+++ b/internal/controller/chianode/helpers.go
@@ -212,6 +212,11 @@ func getChiaEnv(ctx context.Context, node k8schianetv1.ChiaNode) []corev1.EnvVar
 			Name:  "self_hostname",
 			Value: *node.Spec.ChiaConfig.SelfHostname,
 		})
+	} else {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: "0.0.0.0",
+		})
 	}
 
 	return env

--- a/internal/controller/chiaseeder/helpers.go
+++ b/internal/controller/chiaseeder/helpers.go
@@ -191,6 +191,11 @@ func getChiaEnv(seeder k8schianetv1.ChiaSeeder) []corev1.EnvVar {
 			Name:  "self_hostname",
 			Value: *seeder.Spec.ChiaConfig.SelfHostname,
 		})
+	} else {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: "0.0.0.0",
+		})
 	}
 
 	// seeder_bootstrap_peers env var

--- a/internal/controller/chiatimelord/helpers.go
+++ b/internal/controller/chiatimelord/helpers.go
@@ -174,6 +174,11 @@ func getChiaEnv(tl k8schianetv1.ChiaTimelord) []corev1.EnvVar {
 			Name:  "self_hostname",
 			Value: *tl.Spec.ChiaConfig.SelfHostname,
 		})
+	} else {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: "0.0.0.0",
+		})
 	}
 
 	// node peer env var

--- a/internal/controller/chiawallet/helpers.go
+++ b/internal/controller/chiawallet/helpers.go
@@ -227,6 +227,11 @@ func getChiaEnv(ctx context.Context, wallet k8schianetv1.ChiaWallet) []corev1.En
 			Name:  "self_hostname",
 			Value: *wallet.Spec.ChiaConfig.SelfHostname,
 		})
+	} else {
+		env = append(env, corev1.EnvVar{
+			Name:  "self_hostname",
+			Value: "0.0.0.0",
+		})
 	}
 
 	// keys env var


### PR DESCRIPTION
Defaulting this to something else makes it confusing to people why the default RPC/Daemon Services are unusable. The default for chia-docker of setting self_hostname to `127.0.0.1` was used here for historical reasons, but I think it actually makes more sense to default this to `0.0.0.0` and leave it up to the kubernetes administrator to set NetworkPolicies to secure these Service endpoints.