### PR TITLE
Overwrite annotations for internal and headless full_node Services

### DIFF
--- a/internal/controller/chianode/assemblers.go
+++ b/internal/controller/chianode/assemblers.go
@@ -207,6 +207,7 @@ func assembleLocalPeerService(node k8schianetv1.ChiaNode) corev1.Service {
 
 	srv.Name = srv.Name + "-internal"
 	srv.Annotations = node.Spec.AdditionalMetadata.Annotations // Overwrites the annotations from the peer Service, since those may contain some related to tools like external-dns
+	srv.Spec.Type = "ClusterIP"
 	local := corev1.ServiceInternalTrafficPolicyLocal
 	srv.Spec.InternalTrafficPolicy = &local
 

--- a/internal/controller/chianode/assemblers.go
+++ b/internal/controller/chianode/assemblers.go
@@ -194,6 +194,7 @@ func assembleHeadlessPeerService(node k8schianetv1.ChiaNode) corev1.Service {
 	srv := assemblePeerService(node)
 
 	srv.Name = srv.Name + "-headless"
+	srv.Annotations = node.Spec.AdditionalMetadata.Annotations // Overwrites the annotations from the peer Service, since those may contain some related to tools like external-dns
 	srv.Spec.Type = "ClusterIP"
 	srv.Spec.ClusterIP = "None"
 
@@ -205,6 +206,7 @@ func assembleLocalPeerService(node k8schianetv1.ChiaNode) corev1.Service {
 	srv := assemblePeerService(node)
 
 	srv.Name = srv.Name + "-internal"
+	srv.Annotations = node.Spec.AdditionalMetadata.Annotations // Overwrites the annotations from the peer Service, since those may contain some related to tools like external-dns
 	local := corev1.ServiceInternalTrafficPolicyLocal
 	srv.Spec.InternalTrafficPolicy = &local
 


### PR DESCRIPTION
Since these are intended to be internal, and there are many supported configurations for the main Peer Service, these fields needed to be overwritten on the internal/headless Services to keep them internal. Annotations in particular can have config for tools like external-dns.