### PR TITLE
Add All-port Service config for all resources

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -105,6 +105,15 @@ jobs:
           fi
           echo "Expected 1 endpoint, found $service_endpoints_number"
 
+      - name: Check to make sure ChiaNode all-port Service has one endpoint
+        run: |
+          service_endpoints_number=$(kubectl get endpoints chianode-test-node-all -o json | jq '.subsets[].addresses | length')
+          if [ "$service_endpoints_number" -ne 1 ]; then
+            echo "ChiaNode all-port Service was found to have $service_endpoints_number endpoints, expected 1"
+            exit 1
+          fi
+          echo "Expected 1 endpoint, found $service_endpoints_number"
+
       - name: Check to make sure ChiaNode RPC Service has one endpoint
         run: |
           service_endpoints_number=$(kubectl get endpoints chianode-test-node-rpc -o json | jq '.subsets[].addresses | length')

--- a/api/v1/chiacommon_types.go
+++ b/api/v1/chiacommon_types.go
@@ -129,6 +129,11 @@ type CommonSpecChia struct {
 	// +optional
 	RPCService Service `json:"rpcService,omitempty"`
 
+	// AllService defines settings for a Service that contains all the ports from the peer, daemon, and RPC Services installed with any Chia component resource.
+	// This Service will default to being enabled with a ClusterIP Service type.
+	// +optional
+	AllService Service `json:"allService,omitempty"`
+
 	// Periodic probe of container liveness.
 	// +optional
 	LivenessProbe *corev1.Probe `json:"livenessProbe,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1235,6 +1235,7 @@ func (in *CommonSpecChia) DeepCopyInto(out *CommonSpecChia) {
 	in.PeerService.DeepCopyInto(&out.PeerService)
 	in.DaemonService.DeepCopyInto(&out.DaemonService)
 	in.RPCService.DeepCopyInto(&out.RPCService)
+	in.AllService.DeepCopyInto(&out.AllService)
 	if in.LivenessProbe != nil {
 		in, out := &in.LivenessProbe, &out.LivenessProbe
 		*out = new(corev1.Probe)

--- a/config/crd/bases/k8s.chia.net_chiacrawlers.yaml
+++ b/config/crd/bases/k8s.chia.net_chiacrawlers.yaml
@@ -970,6 +970,51 @@ spec:
                 description: ChiaConfig defines the configuration options available
                   to Chia component containers
                 properties:
+                  allService:
+                    description: |-
+                      AllService defines settings for a Service that contains all the ports from the peer, daemon, and RPC Services installed with any Chia component resource.
+                      This Service will default to being enabled with a ClusterIP Service type.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of string keys and values
+                          to attach to created objects
+                        type: object
+                      enabled:
+                        description: Enabled is a boolean selector for a Service if
+                          it should be generated.
+                        type: boolean
+                      ipFamilies:
+                        description: IPFamilies represents a list of IP families (IPv4
+                          and/or IPv6) required by a Service
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by a Service
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values to
+                          attach to created objects
+                        type: object
+                      rollIntoPeerService:
+                        description: |-
+                          RollIntoPeerService tells the controller to not actually generate this Service, but instead roll the Service ports of this Service into the peer Service.
+                          The peer Service is often considered the primary Service generated for a chia resource, as it is the most likely Service to expose publicly.
+                          This option is default, and only provides its functionality on chia-healthcheck Services. It may be included to other Services someday if a use case arises.
+                        type: boolean
+                      type:
+                        description: ServiceType is the Type of the Service. Defaults
+                          to ClusterIP
+                        type: string
+                    type: object
                   caSecretName:
                     description: CASecretName is the name of the secret that contains
                       the CA crt and key. Not required for seeders.

--- a/config/crd/bases/k8s.chia.net_chiafarmers.yaml
+++ b/config/crd/bases/k8s.chia.net_chiafarmers.yaml
@@ -970,6 +970,51 @@ spec:
                 description: ChiaConfig defines the configuration options available
                   to Chia component containers
                 properties:
+                  allService:
+                    description: |-
+                      AllService defines settings for a Service that contains all the ports from the peer, daemon, and RPC Services installed with any Chia component resource.
+                      This Service will default to being enabled with a ClusterIP Service type.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of string keys and values
+                          to attach to created objects
+                        type: object
+                      enabled:
+                        description: Enabled is a boolean selector for a Service if
+                          it should be generated.
+                        type: boolean
+                      ipFamilies:
+                        description: IPFamilies represents a list of IP families (IPv4
+                          and/or IPv6) required by a Service
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by a Service
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values to
+                          attach to created objects
+                        type: object
+                      rollIntoPeerService:
+                        description: |-
+                          RollIntoPeerService tells the controller to not actually generate this Service, but instead roll the Service ports of this Service into the peer Service.
+                          The peer Service is often considered the primary Service generated for a chia resource, as it is the most likely Service to expose publicly.
+                          This option is default, and only provides its functionality on chia-healthcheck Services. It may be included to other Services someday if a use case arises.
+                        type: boolean
+                      type:
+                        description: ServiceType is the Type of the Service. Defaults
+                          to ClusterIP
+                        type: string
+                    type: object
                   caSecretName:
                     description: CASecretName is the name of the secret that contains
                       the CA crt and key. Not required for seeders.

--- a/config/crd/bases/k8s.chia.net_chiaharvesters.yaml
+++ b/config/crd/bases/k8s.chia.net_chiaharvesters.yaml
@@ -970,6 +970,51 @@ spec:
                 description: ChiaConfig defines the configuration options available
                   to Chia component containers
                 properties:
+                  allService:
+                    description: |-
+                      AllService defines settings for a Service that contains all the ports from the peer, daemon, and RPC Services installed with any Chia component resource.
+                      This Service will default to being enabled with a ClusterIP Service type.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of string keys and values
+                          to attach to created objects
+                        type: object
+                      enabled:
+                        description: Enabled is a boolean selector for a Service if
+                          it should be generated.
+                        type: boolean
+                      ipFamilies:
+                        description: IPFamilies represents a list of IP families (IPv4
+                          and/or IPv6) required by a Service
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by a Service
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values to
+                          attach to created objects
+                        type: object
+                      rollIntoPeerService:
+                        description: |-
+                          RollIntoPeerService tells the controller to not actually generate this Service, but instead roll the Service ports of this Service into the peer Service.
+                          The peer Service is often considered the primary Service generated for a chia resource, as it is the most likely Service to expose publicly.
+                          This option is default, and only provides its functionality on chia-healthcheck Services. It may be included to other Services someday if a use case arises.
+                        type: boolean
+                      type:
+                        description: ServiceType is the Type of the Service. Defaults
+                          to ClusterIP
+                        type: string
+                    type: object
                   caSecretName:
                     description: CASecretName is the name of the secret that contains
                       the CA crt and key. Not required for seeders.

--- a/config/crd/bases/k8s.chia.net_chiaintroducers.yaml
+++ b/config/crd/bases/k8s.chia.net_chiaintroducers.yaml
@@ -970,6 +970,51 @@ spec:
                 description: ChiaConfig defines the configuration options available
                   to Chia component containers
                 properties:
+                  allService:
+                    description: |-
+                      AllService defines settings for a Service that contains all the ports from the peer, daemon, and RPC Services installed with any Chia component resource.
+                      This Service will default to being enabled with a ClusterIP Service type.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of string keys and values
+                          to attach to created objects
+                        type: object
+                      enabled:
+                        description: Enabled is a boolean selector for a Service if
+                          it should be generated.
+                        type: boolean
+                      ipFamilies:
+                        description: IPFamilies represents a list of IP families (IPv4
+                          and/or IPv6) required by a Service
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by a Service
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values to
+                          attach to created objects
+                        type: object
+                      rollIntoPeerService:
+                        description: |-
+                          RollIntoPeerService tells the controller to not actually generate this Service, but instead roll the Service ports of this Service into the peer Service.
+                          The peer Service is often considered the primary Service generated for a chia resource, as it is the most likely Service to expose publicly.
+                          This option is default, and only provides its functionality on chia-healthcheck Services. It may be included to other Services someday if a use case arises.
+                        type: boolean
+                      type:
+                        description: ServiceType is the Type of the Service. Defaults
+                          to ClusterIP
+                        type: string
+                    type: object
                   caSecretName:
                     description: CASecretName is the name of the secret that contains
                       the CA crt and key. Not required for introducers.

--- a/config/crd/bases/k8s.chia.net_chianodes.yaml
+++ b/config/crd/bases/k8s.chia.net_chianodes.yaml
@@ -970,6 +970,51 @@ spec:
                 description: ChiaConfig defines the configuration options available
                   to Chia component containers
                 properties:
+                  allService:
+                    description: |-
+                      AllService defines settings for a Service that contains all the ports from the peer, daemon, and RPC Services installed with any Chia component resource.
+                      This Service will default to being enabled with a ClusterIP Service type.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of string keys and values
+                          to attach to created objects
+                        type: object
+                      enabled:
+                        description: Enabled is a boolean selector for a Service if
+                          it should be generated.
+                        type: boolean
+                      ipFamilies:
+                        description: IPFamilies represents a list of IP families (IPv4
+                          and/or IPv6) required by a Service
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by a Service
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values to
+                          attach to created objects
+                        type: object
+                      rollIntoPeerService:
+                        description: |-
+                          RollIntoPeerService tells the controller to not actually generate this Service, but instead roll the Service ports of this Service into the peer Service.
+                          The peer Service is often considered the primary Service generated for a chia resource, as it is the most likely Service to expose publicly.
+                          This option is default, and only provides its functionality on chia-healthcheck Services. It may be included to other Services someday if a use case arises.
+                        type: boolean
+                      type:
+                        description: ServiceType is the Type of the Service. Defaults
+                          to ClusterIP
+                        type: string
+                    type: object
                   caSecretName:
                     description: CASecretName is the name of the secret that contains
                       the CA crt and key. Not required for seeders.

--- a/config/crd/bases/k8s.chia.net_chiaseeders.yaml
+++ b/config/crd/bases/k8s.chia.net_chiaseeders.yaml
@@ -970,6 +970,51 @@ spec:
                 description: ChiaConfig defines the configuration options available
                   to Chia component containers
                 properties:
+                  allService:
+                    description: |-
+                      AllService defines settings for a Service that contains all the ports from the peer, daemon, and RPC Services installed with any Chia component resource.
+                      This Service will default to being enabled with a ClusterIP Service type.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of string keys and values
+                          to attach to created objects
+                        type: object
+                      enabled:
+                        description: Enabled is a boolean selector for a Service if
+                          it should be generated.
+                        type: boolean
+                      ipFamilies:
+                        description: IPFamilies represents a list of IP families (IPv4
+                          and/or IPv6) required by a Service
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by a Service
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values to
+                          attach to created objects
+                        type: object
+                      rollIntoPeerService:
+                        description: |-
+                          RollIntoPeerService tells the controller to not actually generate this Service, but instead roll the Service ports of this Service into the peer Service.
+                          The peer Service is often considered the primary Service generated for a chia resource, as it is the most likely Service to expose publicly.
+                          This option is default, and only provides its functionality on chia-healthcheck Services. It may be included to other Services someday if a use case arises.
+                        type: boolean
+                      type:
+                        description: ServiceType is the Type of the Service. Defaults
+                          to ClusterIP
+                        type: string
+                    type: object
                   bootstrapPeer:
                     description: BootstrapPeer a peer to bootstrap the seeder's peer
                       database

--- a/config/crd/bases/k8s.chia.net_chiatimelords.yaml
+++ b/config/crd/bases/k8s.chia.net_chiatimelords.yaml
@@ -970,6 +970,51 @@ spec:
                 description: ChiaConfig defines the configuration options available
                   to Chia component containers
                 properties:
+                  allService:
+                    description: |-
+                      AllService defines settings for a Service that contains all the ports from the peer, daemon, and RPC Services installed with any Chia component resource.
+                      This Service will default to being enabled with a ClusterIP Service type.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of string keys and values
+                          to attach to created objects
+                        type: object
+                      enabled:
+                        description: Enabled is a boolean selector for a Service if
+                          it should be generated.
+                        type: boolean
+                      ipFamilies:
+                        description: IPFamilies represents a list of IP families (IPv4
+                          and/or IPv6) required by a Service
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by a Service
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values to
+                          attach to created objects
+                        type: object
+                      rollIntoPeerService:
+                        description: |-
+                          RollIntoPeerService tells the controller to not actually generate this Service, but instead roll the Service ports of this Service into the peer Service.
+                          The peer Service is often considered the primary Service generated for a chia resource, as it is the most likely Service to expose publicly.
+                          This option is default, and only provides its functionality on chia-healthcheck Services. It may be included to other Services someday if a use case arises.
+                        type: boolean
+                      type:
+                        description: ServiceType is the Type of the Service. Defaults
+                          to ClusterIP
+                        type: string
+                    type: object
                   caSecretName:
                     description: CASecretName is the name of the secret that contains
                       the CA crt and key. Not required for seeders.

--- a/config/crd/bases/k8s.chia.net_chiawallets.yaml
+++ b/config/crd/bases/k8s.chia.net_chiawallets.yaml
@@ -970,6 +970,51 @@ spec:
                 description: ChiaConfig defines the configuration options available
                   to Chia component containers
                 properties:
+                  allService:
+                    description: |-
+                      AllService defines settings for a Service that contains all the ports from the peer, daemon, and RPC Services installed with any Chia component resource.
+                      This Service will default to being enabled with a ClusterIP Service type.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of string keys and values
+                          to attach to created objects
+                        type: object
+                      enabled:
+                        description: Enabled is a boolean selector for a Service if
+                          it should be generated.
+                        type: boolean
+                      ipFamilies:
+                        description: IPFamilies represents a list of IP families (IPv4
+                          and/or IPv6) required by a Service
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by a Service
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values to
+                          attach to created objects
+                        type: object
+                      rollIntoPeerService:
+                        description: |-
+                          RollIntoPeerService tells the controller to not actually generate this Service, but instead roll the Service ports of this Service into the peer Service.
+                          The peer Service is often considered the primary Service generated for a chia resource, as it is the most likely Service to expose publicly.
+                          This option is default, and only provides its functionality on chia-healthcheck Services. It may be included to other Services someday if a use case arises.
+                        type: boolean
+                      type:
+                        description: ServiceType is the Type of the Service. Defaults
+                          to ClusterIP
+                        type: string
+                    type: object
                   caSecretName:
                     description: CASecretName is the name of the secret that contains
                       the CA crt and key. Not required for seeders.

--- a/internal/controller/chiacrawler/controller.go
+++ b/internal/controller/chiacrawler/controller.go
@@ -105,6 +105,39 @@ func (r *ChiaCrawlerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
+	if kube.ShouldMakeService(crawler.Spec.ChiaConfig.AllService, true) {
+		srv := assembleAllService(crawler)
+		if err := controllerutil.SetControllerReference(&crawler, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
+		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
+		if err != nil {
+			if res == nil {
+				res = &reconcile.Result{}
+			}
+			metrics.OperatorErrors.Add(1.0)
+			r.Recorder.Event(&crawler, corev1.EventTypeWarning, "Failed", "Failed to create crawler all-ports Service -- Check operator logs.")
+			return *res, fmt.Errorf("ChiaCrawlerReconciler ChiaCrawler=%s encountered error reconciling crawler all-ports Service: %v", req.NamespacedName, err)
+		}
+	} else {
+		// Need to check if the resource exists and delete if it does
+		var srv corev1.Service
+		err := r.Get(ctx, types.NamespacedName{
+			Namespace: req.NamespacedName.Namespace,
+			Name:      fmt.Sprintf(chiacrawlerNamePattern, crawler.Name) + "-all",
+		}, &srv)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Error(err, fmt.Sprintf("ChiaCrawlerReconciler ChiaCrawler=%s unable to GET ChiaCrawler all-ports Service resource", req.NamespacedName))
+			}
+		} else {
+			err = r.Delete(ctx, &srv)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("ChiaCrawlerReconciler ChiaCrawler=%s unable to DELETE ChiaCrawler all-ports Service resource", req.NamespacedName))
+			}
+		}
+	}
+
 	if kube.ShouldMakeService(crawler.Spec.ChiaConfig.DaemonService, true) {
 		srv := assembleDaemonService(crawler)
 		if err := controllerutil.SetControllerReference(&crawler, &srv, r.Scheme); err != nil {

--- a/internal/controller/chiawallet/controller.go
+++ b/internal/controller/chiawallet/controller.go
@@ -107,6 +107,39 @@ func (r *ChiaWalletReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
+	if kube.ShouldMakeService(wallet.Spec.ChiaConfig.AllService, true) {
+		srv := assembleAllService(wallet)
+		if err := controllerutil.SetControllerReference(&wallet, &srv, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
+		res, err := kube.ReconcileService(ctx, resourceReconciler, srv)
+		if err != nil {
+			if res == nil {
+				res = &reconcile.Result{}
+			}
+			metrics.OperatorErrors.Add(1.0)
+			r.Recorder.Event(&wallet, corev1.EventTypeWarning, "Failed", "Failed to create wallet all-ports Service -- Check operator logs.")
+			return *res, fmt.Errorf("ChiaWalletReconciler ChiaWallet=%s encountered error reconciling wallet all-ports Service: %v", req.NamespacedName, err)
+		}
+	} else {
+		// Need to check if the resource exists and delete if it does
+		var srv corev1.Service
+		err := r.Get(ctx, types.NamespacedName{
+			Namespace: req.NamespacedName.Namespace,
+			Name:      fmt.Sprintf(chiawalletNamePattern, wallet.Name) + "-all",
+		}, &srv)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Error(err, fmt.Sprintf("ChiaWalletReconciler ChiaWallet=%s unable to GET ChiaWallet all-ports Service resource", req.NamespacedName))
+			}
+		} else {
+			err = r.Delete(ctx, &srv)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("ChiaWalletReconciler ChiaWallet=%s unable to DELETE ChiaWallet all-ports Service resource", req.NamespacedName))
+			}
+		}
+	}
+
 	if kube.ShouldMakeService(wallet.Spec.ChiaConfig.DaemonService, true) {
 		srv := assembleDaemonService(wallet)
 		if err := controllerutil.SetControllerReference(&wallet, &srv, r.Scheme); err != nil {

--- a/internal/controller/common/consts/consts.go
+++ b/internal/controller/common/consts/consts.go
@@ -97,7 +97,7 @@ const (
 	// WalletPort defines the port for wallet instances
 	WalletPort = 8449
 
-	// walletRPCPort defines the port for the wallet RPC
+	// WalletRPCPort defines the port for the wallet RPC
 	WalletRPCPort = 9256
 
 	// ChiaExporterPort defines the port for Chia Exporter instances


### PR DESCRIPTION
A while ago we split up all the ports attributed to a Chia deployment to multiple Services so that you could granularly expose certain ports to the open internet while leaving some private (like the daemon/rpc ports) but we found that it's sometimes ideal when writing applications that call on chia components to have a Service that encompasses all of the ports, so that you can have one cluster DNS endpoint for the peer/daemon/rpc ports.