### PR TITLE
Fix introducer full_node port in chia container ports

### DIFF
--- a/internal/controller/chiaintroducer/assemblers.go
+++ b/internal/controller/chiaintroducer/assemblers.go
@@ -266,7 +266,7 @@ func assembleChiaContainer(introducer k8schianetv1.ChiaIntroducer) corev1.Contai
 			},
 			{
 				Name:          "peers",
-				ContainerPort: getFullNodePort(introducer),
+				ContainerPort: kube.GetFullNodePort(introducer.Spec.ChiaConfig.CommonSpecChia),
 				Protocol:      "TCP",
 			},
 		},

--- a/internal/controller/chiaintroducer/helpers.go
+++ b/internal/controller/chiaintroducer/helpers.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 
 	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
-	"github.com/chia-network/chia-operator/internal/controller/common/consts"
 )
 
 // getChiaVolumes retrieves the requisite volumes from the Chia config struct
@@ -199,12 +198,4 @@ func getChiaEnv(introducer k8schianetv1.ChiaIntroducer) []corev1.EnvVar {
 	}
 
 	return env
-}
-
-// getFullNodePort determines the correct full_node port to use
-func getFullNodePort(introducer k8schianetv1.ChiaIntroducer) int32 {
-	if introducer.Spec.ChiaConfig.Testnet != nil && *introducer.Spec.ChiaConfig.Testnet {
-		return consts.TestnetNodePort
-	}
-	return consts.MainnetNodePort
 }


### PR DESCRIPTION
This fixes an issue where the ChiaIntroducer assembler logic used the incorrect network port for non-default testnets (ie. you're using `testnet: false` in combination with `networkPort: <port_integer>` in your introducer's custom resource. The default testnet (testnet11) would have used the correct network port for full_nodes.