### PR TITLE
Add assembler tests for ChiaCA

### DIFF
--- a/api/v1/chiaca_types.go
+++ b/api/v1/chiaca_types.go
@@ -19,7 +19,6 @@ type ChiaCASpec struct {
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 
 	// Secret defines the name of the secret to contain CA files
-	// +kubebuilder:default="chia-ca"
 	// +optional
 	Secret string `json:"secret,omitempty"`
 }

--- a/config/crd/bases/k8s.chia.net_chiacas.yaml
+++ b/config/crd/bases/k8s.chia.net_chiacas.yaml
@@ -47,7 +47,6 @@ spec:
                   generator image
                 type: string
               secret:
-                default: chia-ca
                 description: Secret defines the name of the secret to contain CA files
                 type: string
             type: object

--- a/internal/controller/chiaca/assemblers.go
+++ b/internal/controller/chiaca/assemblers.go
@@ -20,8 +20,15 @@ import (
 
 const chiacaNamePattern = "%s-chiaca-generator"
 
+const defaultChiaCASecretName = "chiaca"
+
 // assembleJob assembles the Job resource for a ChiaCA CR
 func assembleJob(ca k8schianetv1.ChiaCA) batchv1.Job {
+	secretName := defaultChiaCASecretName
+	if ca.Spec.Secret != "" {
+		secretName = ca.Spec.Secret
+	}
+
 	var job = batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf(chiacaNamePattern, ca.Name),
@@ -43,7 +50,7 @@ func assembleJob(ca k8schianetv1.ChiaCA) batchv1.Job {
 								},
 								{
 									Name:  "SECRET_NAME",
-									Value: ca.Spec.Secret,
+									Value: secretName,
 								},
 							},
 						},

--- a/internal/controller/chiaca/assemblers_test.go
+++ b/internal/controller/chiaca/assemblers_test.go
@@ -1,0 +1,144 @@
+package chiaca
+
+import (
+	"fmt"
+	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
+	"github.com/chia-network/chia-operator/internal/controller/common/consts"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+var testCA = k8schianetv1.ChiaCA{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "ChiaCA",
+		APIVersion: "k8s.chia.net/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "testname",
+		Namespace: "testnamespace",
+	},
+	Spec: k8schianetv1.ChiaCASpec{
+		Secret: "test-ca-secret",
+	},
+}
+
+func TestAssembleJob(t *testing.T) {
+	var backoffLimit int32 = 3
+	expected := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testname-chiaca-generator",
+			Namespace: "testnamespace",
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "testname",
+				"app.kubernetes.io/name":       "testname",
+				"app.kubernetes.io/managed-by": "chia-operator",
+				"k8s.chia.net/provenance":      "ChiaCA.testnamespace.testname",
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &backoffLimit,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy:      "Never",
+					ServiceAccountName: "testname-chiaca-generator",
+					Containers: []corev1.Container{
+						{
+							Name:  "chiaca-generator",
+							Image: fmt.Sprintf("%s:%s", consts.DefaultChiaCAImageName, consts.DefaultChiaCAImageTag),
+							Env: []corev1.EnvVar{
+								{
+									Name:  "NAMESPACE",
+									Value: "testnamespace",
+								},
+								{
+									Name:  "SECRET_NAME",
+									Value: "test-ca-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	actual := assembleJob(testCA)
+	require.Equal(t, expected, actual)
+}
+
+func TestAssembleServiceAccount(t *testing.T) {
+	expected := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testname-chiaca-generator",
+			Namespace: "testnamespace",
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "testname",
+				"app.kubernetes.io/name":       "testname",
+				"app.kubernetes.io/managed-by": "chia-operator",
+				"k8s.chia.net/provenance":      "ChiaCA.testnamespace.testname",
+			},
+		},
+	}
+	actual := assembleServiceAccount(testCA)
+	require.Equal(t, expected, actual)
+}
+
+func TestAssembleRole(t *testing.T) {
+	expected := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testname-chiaca-generator",
+			Namespace: "testnamespace",
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "testname",
+				"app.kubernetes.io/name":       "testname",
+				"app.kubernetes.io/managed-by": "chia-operator",
+				"k8s.chia.net/provenance":      "ChiaCA.testnamespace.testname",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"secrets",
+				},
+				Verbs: []string{
+					"create",
+				},
+			},
+		},
+	}
+	actual := assembleRole(testCA)
+	require.Equal(t, expected, actual)
+}
+
+func TestAssembleRoleBinding(t *testing.T) {
+	expected := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testname-chiaca-generator",
+			Namespace: "testnamespace",
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "testname",
+				"app.kubernetes.io/name":       "testname",
+				"app.kubernetes.io/managed-by": "chia-operator",
+				"k8s.chia.net/provenance":      "ChiaCA.testnamespace.testname",
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "ServiceAccount",
+				Name: "testname-chiaca-generator",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "Role",
+			Name: "testname-chiaca-generator",
+		},
+	}
+	actual := assembleRoleBinding(testCA)
+	require.Equal(t, expected, actual)
+}

--- a/internal/controller/chiaca/assemblers_test.go
+++ b/internal/controller/chiaca/assemblers_test.go
@@ -24,20 +24,6 @@ var testCA = k8schianetv1.ChiaCA{
 	},
 }
 
-var testCACustomSecret = k8schianetv1.ChiaCA{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "ChiaCA",
-		APIVersion: "k8s.chia.net/v1",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "testname",
-		Namespace: "testnamespace",
-	},
-	Spec: k8schianetv1.ChiaCASpec{
-		Secret: "test-ca-secret",
-	},
-}
-
 var testObjMeta = metav1.ObjectMeta{
 	Name:      "testname-chiaca-generator",
 	Namespace: "testnamespace",

--- a/internal/controller/chiaca/assemblers_test.go
+++ b/internal/controller/chiaca/assemblers_test.go
@@ -27,19 +27,21 @@ var testCA = k8schianetv1.ChiaCA{
 	},
 }
 
+var testObjMeta = metav1.ObjectMeta{
+	Name:      "testname-chiaca-generator",
+	Namespace: "testnamespace",
+	Labels: map[string]string{
+		"app.kubernetes.io/instance":   "testname",
+		"app.kubernetes.io/name":       "testname",
+		"app.kubernetes.io/managed-by": "chia-operator",
+		"k8s.chia.net/provenance":      "ChiaCA.testnamespace.testname",
+	},
+}
+
 func TestAssembleJob(t *testing.T) {
 	var backoffLimit int32 = 3
 	expected := batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testname-chiaca-generator",
-			Namespace: "testnamespace",
-			Labels: map[string]string{
-				"app.kubernetes.io/instance":   "testname",
-				"app.kubernetes.io/name":       "testname",
-				"app.kubernetes.io/managed-by": "chia-operator",
-				"k8s.chia.net/provenance":      "ChiaCA.testnamespace.testname",
-			},
-		},
+		ObjectMeta: testObjMeta,
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &backoffLimit,
 			Template: corev1.PodTemplateSpec{
@@ -72,16 +74,7 @@ func TestAssembleJob(t *testing.T) {
 
 func TestAssembleServiceAccount(t *testing.T) {
 	expected := corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testname-chiaca-generator",
-			Namespace: "testnamespace",
-			Labels: map[string]string{
-				"app.kubernetes.io/instance":   "testname",
-				"app.kubernetes.io/name":       "testname",
-				"app.kubernetes.io/managed-by": "chia-operator",
-				"k8s.chia.net/provenance":      "ChiaCA.testnamespace.testname",
-			},
-		},
+		ObjectMeta: testObjMeta,
 	}
 	actual := assembleServiceAccount(testCA)
 	require.Equal(t, expected, actual)
@@ -89,16 +82,7 @@ func TestAssembleServiceAccount(t *testing.T) {
 
 func TestAssembleRole(t *testing.T) {
 	expected := rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testname-chiaca-generator",
-			Namespace: "testnamespace",
-			Labels: map[string]string{
-				"app.kubernetes.io/instance":   "testname",
-				"app.kubernetes.io/name":       "testname",
-				"app.kubernetes.io/managed-by": "chia-operator",
-				"k8s.chia.net/provenance":      "ChiaCA.testnamespace.testname",
-			},
-		},
+		ObjectMeta: testObjMeta,
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{
@@ -119,16 +103,7 @@ func TestAssembleRole(t *testing.T) {
 
 func TestAssembleRoleBinding(t *testing.T) {
 	expected := rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testname-chiaca-generator",
-			Namespace: "testnamespace",
-			Labels: map[string]string{
-				"app.kubernetes.io/instance":   "testname",
-				"app.kubernetes.io/name":       "testname",
-				"app.kubernetes.io/managed-by": "chia-operator",
-				"k8s.chia.net/provenance":      "ChiaCA.testnamespace.testname",
-			},
-		},
+		ObjectMeta: testObjMeta,
 		Subjects: []rbacv1.Subject{
 			{
 				Kind: "ServiceAccount",

--- a/internal/controller/chiaca/assemblers_test.go
+++ b/internal/controller/chiaca/assemblers_test.go
@@ -2,6 +2,8 @@ package chiaca
 
 import (
 	"fmt"
+	"testing"
+
 	k8schianetv1 "github.com/chia-network/chia-operator/api/v1"
 	"github.com/chia-network/chia-operator/internal/controller/common/consts"
 	"github.com/stretchr/testify/require"
@@ -9,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 var testCA = k8schianetv1.ChiaCA{


### PR DESCRIPTION
When testing chia-operator changes, a huge focus in manual testing is in deploying various versions of a custom resource to a local k8s cluster deployed via KinD and checking how each of the resources the operator created match some expected state after the assembler functions all took in the custom resource and outputted some resource spec.

In unit testing these assembler functions, we can effectively eliminate that part of manual testing. Testing in a KinD cluster may still be required but instead of using it to prove to ourself that our assembler functions render down their respective custom resource into a specific resource (eg. Service, Deployment, etc) in some expected way, our manual testing would just be about proving to ourself that chia starts and runs healthily, because we've already proven at that point that the k8s resources are correctly configured.