### PR TITLE
Set manager memory limit to 256MiB

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -84,7 +84,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
 ---


### PR DESCRIPTION
In larger clusters this can easily consume more than 128MiB at startup where it finds all the Chia CRDs installed and runs reconcilers on initial startup. This just makes it easier to work on larger clusters with a lot of resources, but is still a very modest memory limit, in my opinion, compared to other software that runs in kubernetes.