### PR TITLE
Set controller defaults for 0.12.3 tag

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,7 +59,7 @@ spec:
           - "--health-probe-bind-address=:8081"
           - "--metrics-bind-address=0.0.0.0:8080"
           - "--leader-elect"
-        image: ghcr.io/chia-network/chia-operator:latest
+        image: ghcr.io/chia-network/chia-operator:0.12.3
         name: manager
         ports:
         - containerPort: 8081

--- a/internal/controller/common/consts/consts.go
+++ b/internal/controller/common/consts/consts.go
@@ -42,19 +42,19 @@ const (
 	DefaultChiaImageName = "ghcr.io/chia-network/chia"
 
 	// DefaultChiaImageTag contains the default tag name for the chia-docker image
-	DefaultChiaImageTag = "latest"
+	DefaultChiaImageTag = "2.4.4"
 
 	// DefaultChiaExporterImageName contains the default image name for the chia-exporter image
 	DefaultChiaExporterImageName = "ghcr.io/chia-network/chia-exporter"
 
 	// DefaultChiaExporterImageTag contains the default tag name for the chia-exporter image
-	DefaultChiaExporterImageTag = "latest"
+	DefaultChiaExporterImageTag = "0.16.1"
 
 	// DefaultChiaHealthcheckImageName contains the default image name for the chia-healthcheck image
 	DefaultChiaHealthcheckImageName = "ghcr.io/chia-network/chia-healthcheck"
 
 	// DefaultChiaHealthcheckImageTag contains the default tag name for the chia-healthcheck image
-	DefaultChiaHealthcheckImageTag = "latest"
+	DefaultChiaHealthcheckImageTag = "0.3.1"
 )
 
 const (


### PR DESCRIPTION
Primarily focused on getting the new chia-exporter in the defaults, which fixes duplicate events when a timeout/reconnect happened (which caused incorrect rate based graphs)