### PR TITLE
Ensure externalTrafficPolicy is not set for the internal versions of peer service

### DIFF
--- a/internal/controller/chianode/assemblers.go
+++ b/internal/controller/chianode/assemblers.go
@@ -245,8 +245,9 @@ func assembleHeadlessPeerService(node k8schianetv1.ChiaNode, fullNodePort int32)
 
 	srv.Name = srv.Name + "-headless"
 	srv.Annotations = node.Spec.AdditionalMetadata.Annotations // Overwrites the annotations from the peer Service, since those may contain some related to tools like external-dns
-	srv.Spec.Type = "ClusterIP"
+	srv.Spec.Type = corev1.ServiceTypeClusterIP
 	srv.Spec.ClusterIP = "None"
+	srv.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyCluster
 
 	return srv
 }
@@ -257,9 +258,10 @@ func assembleLocalPeerService(node k8schianetv1.ChiaNode, fullNodePort int32) co
 
 	srv.Name = srv.Name + "-internal"
 	srv.Annotations = node.Spec.AdditionalMetadata.Annotations // Overwrites the annotations from the peer Service, since those may contain some related to tools like external-dns
-	srv.Spec.Type = "ClusterIP"
+	srv.Spec.Type = corev1.ServiceTypeClusterIP
 	local := corev1.ServiceInternalTrafficPolicyLocal
 	srv.Spec.InternalTrafficPolicy = &local
+	srv.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyCluster
 
 	return srv
 }

--- a/internal/controller/chianode/assemblers.go
+++ b/internal/controller/chianode/assemblers.go
@@ -247,7 +247,7 @@ func assembleHeadlessPeerService(node k8schianetv1.ChiaNode, fullNodePort int32)
 	srv.Annotations = node.Spec.AdditionalMetadata.Annotations // Overwrites the annotations from the peer Service, since those may contain some related to tools like external-dns
 	srv.Spec.Type = corev1.ServiceTypeClusterIP
 	srv.Spec.ClusterIP = "None"
-	srv.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyCluster
+	srv.Spec.ExternalTrafficPolicy = ""
 
 	return srv
 }
@@ -261,7 +261,7 @@ func assembleLocalPeerService(node k8schianetv1.ChiaNode, fullNodePort int32) co
 	srv.Spec.Type = corev1.ServiceTypeClusterIP
 	local := corev1.ServiceInternalTrafficPolicyLocal
 	srv.Spec.InternalTrafficPolicy = &local
-	srv.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyCluster
+	srv.Spec.ExternalTrafficPolicy = ""
 
 	return srv
 }


### PR DESCRIPTION
Ensure that services that are intended to be private but are based on the peerService do not have the same external traffic policy applied