### PR TITLE
Set controller defaults for 0.15.0

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,7 +59,7 @@ spec:
           - "--health-probe-bind-address=:8081"
           - "--metrics-bind-address=0.0.0.0:8080"
           - "--leader-elect"
-        image: ghcr.io/chia-network/chia-operator:latest
+        image: ghcr.io/chia-network/chia-operator:0.15.0
         name: manager
         ports:
         - containerPort: 8081

--- a/internal/controller/common/consts/consts.go
+++ b/internal/controller/common/consts/consts.go
@@ -42,19 +42,19 @@ const (
 	DefaultChiaImageName = "ghcr.io/chia-network/chia"
 
 	// DefaultChiaImageTag contains the default tag name for the chia-docker image
-	DefaultChiaImageTag = "latest"
+	DefaultChiaImageTag = "2.5.3"
 
 	// DefaultChiaExporterImageName contains the default image name for the chia-exporter image
 	DefaultChiaExporterImageName = "ghcr.io/chia-network/chia-exporter"
 
 	// DefaultChiaExporterImageTag contains the default tag name for the chia-exporter image
-	DefaultChiaExporterImageTag = "latest"
+	DefaultChiaExporterImageTag = "0.16.5"
 
 	// DefaultChiaHealthcheckImageName contains the default image name for the chia-healthcheck image
 	DefaultChiaHealthcheckImageName = "ghcr.io/chia-network/chia-healthcheck"
 
 	// DefaultChiaHealthcheckImageTag contains the default tag name for the chia-healthcheck image
-	DefaultChiaHealthcheckImageTag = "latest"
+	DefaultChiaHealthcheckImageTag = "0.4.2"
 )
 
 const (


### PR DESCRIPTION
NOTE: This release introduces a breaking change for ChiaDataLayer users that use `.spec.dataLayerHTTP`. If you use the deprecated dataLayerHTTP configuration in ChiaDataLayer resources, see the new [fileserver configuration docs](https://github.com/Chia-Network/chia-operator/blob/main/docs/chiadatalayer.md#fileserver-configuration).