### PR TITLE
Add SOFT_FORK9_HEIGHT to NetworkConstants

### DIFF
--- a/api/v1/chianetwork_types.go
+++ b/api/v1/chianetwork_types.go
@@ -104,6 +104,9 @@ type NetworkConstants struct {
 	SoftFork8Height *uint32 `json:"SOFT_FORK8_HEIGHT,omitempty"`
 
 	// +optional
+	SoftFork9Height *uint32 `json:"SOFT_FORK9_HEIGHT,omitempty"`
+
+	// +optional
 	PlotFilter128Height *uint32 `json:"PLOT_FILTER_128_HEIGHT,omitempty"`
 
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -2030,6 +2030,11 @@ func (in *NetworkConstants) DeepCopyInto(out *NetworkConstants) {
 		*out = new(uint32)
 		**out = **in
 	}
+	if in.SoftFork9Height != nil {
+		in, out := &in.SoftFork9Height, &out.SoftFork9Height
+		*out = new(uint32)
+		**out = **in
+	}
 	if in.PlotFilter128Height != nil {
 		in, out := &in.PlotFilter128Height, &out.PlotFilter128Height
 		*out = new(uint32)

--- a/config/crd/bases/k8s.chia.net_chianetworks.yaml
+++ b/config/crd/bases/k8s.chia.net_chianetworks.yaml
@@ -129,6 +129,9 @@ spec:
                   SOFT_FORK8_HEIGHT:
                     format: int32
                     type: integer
+                  SOFT_FORK9_HEIGHT:
+                    format: int32
+                    type: integer
                   SUB_SLOT_ITERS_STARTING:
                     format: int64
                     type: integer


### PR DESCRIPTION
## Summary

- Adds optional `SOFT_FORK9_HEIGHT` field (`*uint32`) to `NetworkConstants` in the ChiaNetwork CRD, matching the pattern of the existing `SOFT_FORK8_HEIGHT` and other optional fork height fields
- Field is omitted from the marshaled config when not set, so it has no effect on existing networks
- Regenerated `zz_generated.deepcopy.go` and `config/crd/bases/k8s.chia.net_chianetworks.yaml` via `make generate manifests`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change: adds a new optional constant field and regenerates derived deepcopy/CRD manifests, with no behavior change unless the field is set.
> 
> **Overview**
> Adds **optional** `SOFT_FORK9_HEIGHT` (`*uint32`) to `NetworkConstants` so a `ChiaNetwork` can specify the soft fork 9 activation height.
> 
> Regenerates controller-gen outputs to include the new field in `zz_generated.deepcopy.go` and the CRD OpenAPI schema (`k8s.chia.net_chianetworks.yaml`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40c103d70afbd876459d2e66fb461c40f7893f43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->